### PR TITLE
Userページをグローバルメニューに移動した

### DIFF
--- a/src/admin/components/Routes/Setting/index.tsx
+++ b/src/admin/components/Routes/Setting/index.tsx
@@ -6,8 +6,6 @@ import React, { lazy } from 'react';
 import { Navigate } from 'react-router-dom';
 
 const Project = Loader(lazy(() => import('@admin/pages/Project')));
-const User = Loader(lazy(() => import('@admin/pages/User')));
-const EditUser = Loader(lazy(() => import('@admin/pages/User/Edit')));
 const Role = Loader(lazy(() => import('@admin/pages/Role')));
 const EditRole = Loader(lazy(() => import('@admin/pages/Role/Edit')));
 const ContentType = Loader(lazy(() => import('@admin/pages/ContentType')));
@@ -58,34 +56,6 @@ const SettingRoutes = {
       element: (
         <DocumentInfoProvider {...props('content-types')}>
           <EditContentType />
-        </DocumentInfoProvider>
-      ),
-    },
-
-    // /////////////////////////////////////
-    // Users
-    // /////////////////////////////////////
-    {
-      path: 'users',
-      element: (
-        <DocumentInfoProvider {...props('users')}>
-          <User />
-        </DocumentInfoProvider>
-      ),
-    },
-    {
-      path: 'users/create',
-      element: (
-        <DocumentInfoProvider {...props('users')}>
-          <EditUser />
-        </DocumentInfoProvider>
-      ),
-    },
-    {
-      path: 'users/:id',
-      element: (
-        <DocumentInfoProvider {...props('users')}>
-          <EditUser />
         </DocumentInfoProvider>
       ),
     },

--- a/src/admin/components/Routes/User/index.tsx
+++ b/src/admin/components/Routes/User/index.tsx
@@ -1,0 +1,49 @@
+import Loader from '@admin/components/elements/Loader';
+import MainLayout from '@admin/components/layouts/Main';
+import { DocumentInfoProvider } from '@admin/components/utilities/DocumentInfo';
+import { usersGroupNavItems } from '@admin/utilities/groupNavItems';
+import React, { lazy } from 'react';
+import { Navigate } from 'react-router-dom';
+
+const User = Loader(lazy(() => import('@admin/pages/User')));
+const EditUser = Loader(lazy(() => import('@admin/pages/User/Edit')));
+const group = usersGroupNavItems();
+
+const props = (id: string) => {
+  const item = group.items.find((group) => group.id == id);
+  return { label: item.label, fields: item.fields };
+};
+
+const UserRoutes = {
+  path: '/admin',
+  element: <MainLayout group={group} />,
+  children: [
+    { path: '', element: <Navigate to={group.items[0].href} replace /> },
+    {
+      path: 'users',
+      element: (
+        <DocumentInfoProvider {...props('users')}>
+          <User />
+        </DocumentInfoProvider>
+      ),
+    },
+    {
+      path: 'users/create',
+      element: (
+        <DocumentInfoProvider {...props('users')}>
+          <EditUser />
+        </DocumentInfoProvider>
+      ),
+    },
+    {
+      path: 'users/:id',
+      element: (
+        <DocumentInfoProvider {...props('users')}>
+          <EditUser />
+        </DocumentInfoProvider>
+      ),
+    },
+  ],
+};
+
+export default UserRoutes;

--- a/src/admin/components/Routes/index.ts
+++ b/src/admin/components/Routes/index.ts
@@ -3,9 +3,10 @@ import AuthRoutes from './Auth';
 import CollectionRoutes from './Collection';
 import RootRoutes from './Root';
 import SettingRoutes from './Setting';
+import UserRoutes from './User';
 
 const Routes = () => {
-  return useRoutes([RootRoutes, CollectionRoutes(), SettingRoutes, AuthRoutes]);
+  return useRoutes([RootRoutes, CollectionRoutes(), UserRoutes, SettingRoutes, AuthRoutes]);
 };
 
 export default Routes;

--- a/src/admin/components/elements/Nav/index.tsx
+++ b/src/admin/components/elements/Nav/index.tsx
@@ -6,7 +6,7 @@ import {
   faCircleUser,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Box, Drawer, Link, Tooltip, useMediaQuery, useTheme } from '@mui/material';
+import { Box, Drawer, Link, Tooltip, useMediaQuery, useTheme, alpha } from '@mui/material';
 import config from '@shared/features/config';
 import { User } from '@shared/types';
 import React, { useEffect } from 'react';
@@ -95,6 +95,7 @@ const NavModuleBar = () => {
       sx={{
         alignItems: 'center',
         width: '60px',
+        background: alpha(theme.palette.primary.main, 0.6),
       }}
     >
       <NavHeader />

--- a/src/admin/components/elements/Nav/index.tsx
+++ b/src/admin/components/elements/Nav/index.tsx
@@ -1,12 +1,21 @@
 import { useAuth } from '@admin/components/utilities/Auth';
 import {
   faArrowRightFromBracket,
+  faCircleUser,
   faDiceD6,
   faGear,
-  faCircleUser,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Box, Drawer, Link, Tooltip, useMediaQuery, useTheme, alpha } from '@mui/material';
+import {
+  alpha,
+  Box,
+  Drawer,
+  IconButton,
+  Link,
+  Tooltip,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 import config from '@shared/features/config';
 import { User } from '@shared/types';
 import React, { useEffect } from 'react';
@@ -23,7 +32,7 @@ const modules = [
     href: '/admin/collections',
     icon: (
       <Tooltip title="Content">
-        <FontAwesomeIcon icon={faDiceD6} size="lg" />
+        <FontAwesomeIcon icon={faDiceD6} />
       </Tooltip>
     ),
   },
@@ -35,7 +44,7 @@ const actions = (user?: User) => {
       href: '/admin/auth/logout',
       icon: (
         <Tooltip title="Logout">
-          <FontAwesomeIcon icon={faArrowRightFromBracket} size="lg" />
+          <FontAwesomeIcon icon={faArrowRightFromBracket} />
         </Tooltip>
       ),
     },
@@ -43,7 +52,7 @@ const actions = (user?: User) => {
       href: `/admin/settings/users/${user?.id}`,
       icon: (
         <Tooltip title={user?.userName}>
-          <FontAwesomeIcon icon={faCircleUser} size="lg" />
+          <FontAwesomeIcon icon={faCircleUser} />
         </Tooltip>
       ),
     },
@@ -72,7 +81,7 @@ const NavHeader = () => {
 
 const NavIcon: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
-    <Box
+    <IconButton
       sx={{
         width: '60px',
         height: '60px',
@@ -82,7 +91,7 @@ const NavIcon: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       }}
     >
       {children}
-    </Box>
+    </IconButton>
   );
 };
 
@@ -110,7 +119,7 @@ const NavModuleBar = () => {
         <Link component={RouterLink} to="/admin/settings">
           <NavIcon>
             <Tooltip title="Setting">
-              <FontAwesomeIcon icon={faGear} size="lg" />
+              <FontAwesomeIcon icon={faGear} />
             </Tooltip>
           </NavIcon>
         </Link>

--- a/src/admin/components/elements/Nav/index.tsx
+++ b/src/admin/components/elements/Nav/index.tsx
@@ -4,6 +4,7 @@ import {
   faCircleUser,
   faDiceD6,
   faGear,
+  faUserGroup,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
@@ -32,7 +33,26 @@ const modules = [
     href: '/admin/collections',
     icon: (
       <Tooltip title="Content">
-        <FontAwesomeIcon icon={faDiceD6} />
+        <FontAwesomeIcon icon={faDiceD6} size="sm" />
+      </Tooltip>
+    ),
+  },
+  {
+    href: '/admin/users',
+    icon: (
+      <Tooltip title="User">
+        <FontAwesomeIcon icon={faUserGroup} size="sm" />
+      </Tooltip>
+    ),
+  },
+];
+
+const settings = [
+  {
+    href: '/admin/settings',
+    icon: (
+      <Tooltip title="Setting">
+        <FontAwesomeIcon icon={faGear} size="sm" />
       </Tooltip>
     ),
   },
@@ -49,7 +69,7 @@ const actions = (user?: User) => {
       ),
     },
     {
-      href: `/admin/settings/users/${user?.id}`,
+      href: `/admin/users/${user?.id}`,
       icon: (
         <Tooltip title={user?.userName}>
           <FontAwesomeIcon icon={faCircleUser} />
@@ -115,15 +135,12 @@ const NavModuleBar = () => {
         </Link>
       ))}
 
-      {user?.role.adminAccess && (
-        <Link component={RouterLink} to="/admin/settings">
-          <NavIcon>
-            <Tooltip title="Setting">
-              <FontAwesomeIcon icon={faGear} />
-            </Tooltip>
-          </NavIcon>
-        </Link>
-      )}
+      {user?.role.adminAccess &&
+        settings.map((module) => (
+          <Link component={RouterLink} to={`${module.href}`} key={module.href}>
+            <NavIcon>{module.icon}</NavIcon>
+          </Link>
+        ))}
 
       <Box
         sx={{

--- a/src/admin/utilities/groupNavItems.ts
+++ b/src/admin/utilities/groupNavItems.ts
@@ -23,6 +23,31 @@ export const collectionsGroupNavItems = (collections: Collection[]): Group => {
   };
 };
 
+export const usersGroupNavItems = (): Group => {
+  const path = '/admin';
+
+  return {
+    id: 'group-users',
+    label: 'Users',
+    items: [
+      {
+        id: 'users',
+        label: 'Users',
+        href: `${path}/users`,
+        icon: faUserGroup,
+        fields: [
+          { field: 'name', label: 'Name', type: Type.Text },
+          { field: 'email', label: 'Email', type: Type.Text },
+          { field: 'role', label: 'Role', type: Type.Text },
+          { field: 'userName', label: 'User Name', type: Type.Text },
+          { field: 'status', label: 'Status', type: Type.Text },
+          { field: 'createdAt', label: 'Created At', type: Type.Date },
+        ],
+      },
+    ],
+  };
+};
+
 export const settingsGroupNavItems = (): Group => {
   const path = '/admin/settings';
 
@@ -43,20 +68,6 @@ export const settingsGroupNavItems = (): Group => {
         href: `${path}/content-types`,
         icon: faTable,
         fields: [{ field: 'name', label: 'Name', type: Type.Text }],
-      },
-      {
-        id: 'users',
-        label: 'Users',
-        href: `${path}/users`,
-        icon: faUserGroup,
-        fields: [
-          { field: 'name', label: 'Name', type: Type.Text },
-          { field: 'email', label: 'Email', type: Type.Text },
-          { field: 'role', label: 'Role', type: Type.Text },
-          { field: 'userName', label: 'User Name', type: Type.Text },
-          { field: 'status', label: 'Status', type: Type.Text },
-          { field: 'createdAt', label: 'Created At', type: Type.Date },
-        ],
       },
       {
         id: 'roles',


### PR DESCRIPTION
## 何をしたか
- Userページをグローバルメニューに移動した
  - admin権限がない人も自分のユーザー情報を編集する必要がある。設定配下にあるとアクセス権を付与できないため
- サイドバーのデザイン一部修正