### PR TITLE
ユーザー一覧を取得するAPIの追加

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import './server/listeners/controllers';
 declare const PROJECT_ENTRY: string;
 
 try {

--- a/src/server/controllers/users.ts
+++ b/src/server/controllers/users.ts
@@ -1,0 +1,9 @@
+import asyncMiddleware from '../middleware/async';
+import express from 'express';
+import { users } from 'superfast-core';
+
+const app = express();
+
+app.get('/users', asyncMiddleware(users));
+
+export default app;

--- a/src/server/listeners/controllers.ts
+++ b/src/server/listeners/controllers.ts
@@ -1,0 +1,26 @@
+import users from '../controllers/users';
+import Hooks from '@shared/features/hooks';
+import cookieParser from 'cookie-parser';
+import express, { Express } from 'express';
+
+Hooks.addAction(
+  'api/init',
+  async (app: Express) => {
+    app.use((req, res, next) => {
+      const origin = req.get('origin');
+      res.header('Access-Control-Allow-Origin', origin || '*');
+      res.header('Access-Control-Allow-Headers', 'content-type, auth-token');
+      res.header('Access-Control-Expose-Headers', 'content-type, auth-token');
+      res.header('Access-Control-Allow-Credentials', 'true');
+      res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,PATCH');
+      next();
+    });
+
+    app.use(cookieParser(process.env.SIGNED_COOKIE));
+    app.use(express.json({ limit: process.env.REQ_LIMIT }));
+    app.use(express.urlencoded({ limit: process.env.REQ_LIMIT, extended: true }));
+
+    app.use(users);
+  },
+  { id: 'core/controllers' }
+);

--- a/src/shared/features/api.ts
+++ b/src/shared/features/api.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+import Hooks from './hooks';
+
+const launchApi = async () => {
+  const app = express();
+  await Hooks.doAction('api/init', app);
+
+  return app;
+};
+
+export { launchApi };

--- a/src/shared/features/server.ts
+++ b/src/shared/features/server.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
 import express from 'express';
+import { launchApi } from './api';
 import Hooks from './hooks';
 
 const launch = async () => {
   try {
     const app = express();
+    const apiApp = await launchApi();
+    app.use('/api', apiApp);
     await Hooks.doAction('server/init', app);
 
     app.use(async (_req, res) => {

--- a/src/types/superfast.d.ts
+++ b/src/types/superfast.d.ts
@@ -8,6 +8,7 @@ declare global {
   namespace Superfast {
     interface IActions {
       'server/init': [Express];
+      'api/init': [Express];
 
       [key: string]: any[];
     }


### PR DESCRIPTION
## 何をしたか
- ユーザー一覧を取得するAPIを実装した

## 確認手順
- superfast-core で `npm link` を叩いてシンボリックリンクをつくる
- superfastで `npm link superfast-core` でローカルのパッケージを参照
- `yarn dev`
- `http://localhost:4000/api/users` にアクセスしてユーザー一覧が取得できること

```
{
"users": [
{
"id": 1,
"firstName": "花子",
"lastName": "山田",
"userName": "hanako",
"email": "hanako-yamada@example.com",
"password": "hanako-xxxxxxxxx",
"isActive": true,
"token": null,
"superfast_RoleId": 1,
"createdAt": "2023-01-23T13:03:50.299Z",
"updatedAt": "2023-01-23T13:03:50.299Z"
},
{
"id": 2,
"firstName": "太郎",
"lastName": "田中",
"userName": "taro",
"email": "taro-tanaka@example.com",
"password": "taro-xxxxxxxxx",
"isActive": true,
"token": null,
"superfast_RoleId": 2,
"createdAt": "2023-01-23T13:03:50.300Z",
"updatedAt": "2023-01-23T13:03:50.300Z"
}
]
}
```

## 確認
- [x] superfastローカルでの確認
- [x] スターター経由での確認 

## 他にやること
coreの最新をnpmに上げられなかったので、rollupの設定を見直します🙏
→ done