### PR TITLE
コレクション名のバリデーション対応

### DIFF
--- a/src/admin/fields/schemas/authentications/loginSchema.ts
+++ b/src/admin/fields/schemas/authentications/loginSchema.ts
@@ -1,5 +1,5 @@
 import { SchemaOf } from 'yup';
-import yup from '../yup';
+import yup from '../../yup';
 
 export type FormValues = {
   email: string;

--- a/src/admin/fields/schemas/collections/createCollection.ts
+++ b/src/admin/fields/schemas/collections/createCollection.ts
@@ -1,3 +1,4 @@
+import { TFunction } from 'i18next';
 import { SchemaOf } from 'yup';
 import yup from '../../yup';
 
@@ -6,9 +7,15 @@ export type FormValues = {
   singleton: boolean;
 };
 
-export const createCollection: SchemaOf<FormValues> = yup.object().shape({
-  name: yup.string().required(),
-  singleton: yup.boolean(),
-});
+export const createCollection = (t: TFunction): SchemaOf<FormValues> => {
+  return yup.object().shape({
+    name: yup
+      .string()
+      .matches(/^[_0-9a-zA-Z]+$/, t('yup.custom.alphanumeric_and_underscore'))
+      .required()
+      .max(60),
+    singleton: yup.boolean(),
+  });
+};
 
 export default createCollection;

--- a/src/admin/pages/ContentType/Create/index.tsx
+++ b/src/admin/pages/ContentType/Create/index.tsx
@@ -26,7 +26,7 @@ const CreatePage: React.FC = () => {
     formState: { errors },
   } = useForm<FormValues>({
     defaultValues: { name: '', singleton: false },
-    resolver: yupResolver(createCollectionSchema),
+    resolver: yupResolver(createCollectionSchema(t)),
   });
 
   useEffect(() => {

--- a/src/admin/pages/Login/index.tsx
+++ b/src/admin/pages/Login/index.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from '@admin/components/utilities/Auth';
-import loginSchema, { FormValues } from '@admin/fields/schemas/loginSchema';
+import loginSchema, { FormValues } from '@admin/fields/schemas/authentications/loginSchema';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Button, Stack, TextField } from '@mui/material';
 import React from 'react';

--- a/src/lang/translations/en/translation.json
+++ b/src/lang/translations/en/translation.json
@@ -95,6 +95,9 @@
     },
     "boolean": {
       "is_value": "Must be {{value}}."
+    },
+    "custom": {
+      "alphanumeric_and_underscore": "Please enter single-byte alphanumeric characters and underscore (_)."
     }
   }
 }

--- a/src/lang/translations/ja/translation.json
+++ b/src/lang/translations/ja/translation.json
@@ -95,6 +95,9 @@
     },
     "boolean": {
       "is_value": "{{value}}でなければなりません"
+    },
+    "custom": {
+      "alphanumeric_and_underscore": "半角英数字およびアンダースコア（_）で入力してください"
     }
   }
 }


### PR DESCRIPTION
## 何をしたか
- コレクション名に半角英数字＆アンダースコアのバリデーション追加
  - prisma仕様につきハイフンは禁止
- yupのメッセージを多言語化した