### PR TITLE
チェックボックスの状態はreact-hook-formのfield情報を渡す

### DIFF
--- a/src/admin/pages/ContentType/Edit/index.tsx
+++ b/src/admin/pages/ContentType/Edit/index.tsx
@@ -49,7 +49,7 @@ const EditPage: React.FC = () => {
     handleSubmit,
     formState: {},
   } = useForm<FormValues>({
-    defaultValues: { hidden: meta.hidden, singleton: meta.singleton },
+    defaultValues: { hidden: Boolean(meta.hidden), singleton: Boolean(meta.singleton) },
     resolver: yupResolver(updateCollectionSchema()),
   });
 
@@ -164,7 +164,7 @@ const EditPage: React.FC = () => {
                   <FormControlLabel
                     {...field}
                     label={'Hidden'}
-                    control={<Checkbox defaultChecked={meta.hidden} />}
+                    control={<Checkbox checked={field.value} />}
                   />
                 )}
               />
@@ -179,7 +179,7 @@ const EditPage: React.FC = () => {
                   <FormControlLabel
                     {...field}
                     label={'Singleton'}
-                    control={<Checkbox defaultChecked={meta.singleton} />}
+                    control={<Checkbox checked={field.value} />}
                   />
                 )}
               />


### PR DESCRIPTION
## 何をしたか
- チェックボックスの状態はreact-hook-formのfield情報を渡す
  - muiのエラーを吐いているので