### PR TITLE
コレクションフィールドの必須項目は論理レベルのみにする

### DIFF
--- a/src/server/controllers/fields.ts
+++ b/src/server/controllers/fields.ts
@@ -88,10 +88,6 @@ const addColumnToTable = (field: Field, table: Knex.CreateTableBuilder) => {
       break;
   }
 
-  if (field.required) {
-    column.notNullable();
-  }
-
   return column;
 };
 


### PR DESCRIPTION
## 何をしたか
- コレクションフィールドの必須項目は、論理レベルのみとする
  - 物理に適用すると、後でオプショナルにする余地がなくなるため