### PR TITLE
fix: コンテンツデータは依存フェッチで取得する

### DIFF
--- a/src/admin/pages/collections/Context/index.tsx
+++ b/src/admin/pages/collections/Context/index.tsx
@@ -9,8 +9,9 @@ const Context = createContext({} as ContentContext);
 
 export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const getContents = (slug: string, config?: SWRConfiguration): SWRResponse =>
+    // Fetching data that depends on fields.
     useSWR(
-      `/collections/${slug}/contents`,
+      () => `/collections/${slug}/contents`,
       (url) =>
         api
           .get<{ contents: unknown[] }>(url)


### PR DESCRIPTION
# 何をしたか
- コンテンツデータは依存フェッチで取得する
  - fieldsより先に取得されると、useEffectでエラーになるため
  - https://swr.vercel.app/docs/conditional-fetching#dependent