### PR TITLE
SWRのエラーをグローバルでハンドリングする

### DIFF
--- a/src/admin/components/elements/DeleteDocument/Context/index.tsx
+++ b/src/admin/components/elements/DeleteDocument/Context/index.tsx
@@ -8,10 +8,7 @@ const Context = createContext({} as DocumentContext);
 export const DocumentContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const deleteDocument = (id: string, slug: string): SWRMutationResponse =>
     useSWRMutation(`/${slug}/${id}`, async (url: string, { arg }) => {
-      return api
-        .delete(url, arg)
-        .then((res) => res.data)
-        .catch((err) => Promise.reject(err.message));
+      return api.delete(url, arg).then((res) => res.data);
     });
 
   return (

--- a/src/admin/components/utilities/Auth/index.tsx
+++ b/src/admin/components/utilities/Auth/index.tsx
@@ -17,12 +17,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const { data, trigger } = useSWRMutation(
     user?.id ? `/roles/${user.id}/permissions` : null,
     async (url: string, { arg }) => {
-      return api
-        .get<{ permissions: Permission[] }>(url, arg)
-        .then((res) => {
-          return res.data.permissions;
-        })
-        .catch((err) => Promise.reject(err.message));
+      return api.get<{ permissions: Permission[] }>(url, arg).then((res) => {
+        return res.data.permissions;
+      });
     }
   );
 
@@ -49,13 +46,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     useSWRMutation(
       `/authentications/login`,
       async (url: string, { arg }: { arg: Record<string, any> }) => {
-        return api
-          .post<{ token: string }>(url, arg)
-          .then((res) => {
-            setToken(res.data.token);
-            return res.data;
-          })
-          .catch((err) => Promise.reject(err.message));
+        return api.post<{ token: string }>(url, arg).then((res) => {
+          setToken(res.data.token);
+          return res.data;
+        });
       }
     );
 

--- a/src/admin/components/utilities/Config/index.tsx
+++ b/src/admin/components/utilities/Config/index.tsx
@@ -16,10 +16,7 @@ export const ConfigProvider: React.FC<{ config: Config; children: React.ReactNod
 }) => {
   const [collections, setCollections] = useState([]);
   const { data } = useSWR('/collections', (url) =>
-    api
-      .get<{ collections: Collection[] }>(url)
-      .then((res) => res.data.collections)
-      .catch((err) => Promise.reject(err.message))
+    api.get<{ collections: Collection[] }>(url).then((res) => res.data.collections)
   );
 
   useEffect(() => {

--- a/src/admin/components/utilities/SWRConfigure/index.tsx
+++ b/src/admin/components/utilities/SWRConfigure/index.tsx
@@ -1,17 +1,25 @@
+import { AxiosError } from 'axios';
 import { useSnackbar } from 'notistack';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { SWRConfig } from 'swr';
 import { Props } from './types';
 
 const SWRConfigure: React.FC<Props> = ({ children }) => {
   const { enqueueSnackbar } = useSnackbar();
+  const { t } = useTranslation();
 
   return (
     <SWRConfig
       value={{
         onError: (err) => {
-          if (err.message) {
-            enqueueSnackbar(err.message, { variant: 'error' });
+          if (err instanceof AxiosError) {
+            const data = err.response.data;
+            if (data?.code) {
+              enqueueSnackbar(t(`error.${data.code}` as unknown as TemplateStringsArray), {
+                variant: 'error',
+              });
+            }
           }
         },
       }}

--- a/src/admin/components/utilities/SWRConfigure/index.tsx
+++ b/src/admin/components/utilities/SWRConfigure/index.tsx
@@ -1,0 +1,24 @@
+import { useSnackbar } from 'notistack';
+import React from 'react';
+import { SWRConfig } from 'swr';
+import { Props } from './types';
+
+const SWRConfigure: React.FC<Props> = ({ children }) => {
+  const { enqueueSnackbar } = useSnackbar();
+
+  return (
+    <SWRConfig
+      value={{
+        onError: (err) => {
+          if (err.message) {
+            enqueueSnackbar(err.message, { variant: 'error' });
+          }
+        },
+      }}
+    >
+      {children}
+    </SWRConfig>
+  );
+};
+
+export default SWRConfigure;

--- a/src/admin/components/utilities/SWRConfigure/types.ts
+++ b/src/admin/components/utilities/SWRConfigure/types.ts
@@ -1,0 +1,3 @@
+export type Props = {
+  children?: React.ReactNode;
+};

--- a/src/admin/index.tsx
+++ b/src/admin/index.tsx
@@ -8,6 +8,7 @@ import Routes from './components/routes';
 import { AuthProvider } from './components/utilities/Auth';
 import { ColorModeProvider } from './components/utilities/ColorMode';
 import { ConfigProvider } from './components/utilities/Config';
+import SWRConfigure from './components/utilities/SWRConfigure';
 import { ThemeProvider } from './components/utilities/Theme';
 
 const Index = () => (
@@ -20,14 +21,16 @@ const Index = () => (
       <ColorModeProvider>
         <ThemeProvider>
           <Router>
-            <AuthProvider>
-              <SnackbarProvider
-                maxSnack={3}
-                anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
-              >
-                <Routes />
-              </SnackbarProvider>
-            </AuthProvider>
+            <SnackbarProvider
+              maxSnack={3}
+              anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+            >
+              <SWRConfigure>
+                <AuthProvider>
+                  <Routes />
+                </AuthProvider>
+              </SWRConfigure>
+            </SnackbarProvider>
           </Router>
         </ThemeProvider>
       </ColorModeProvider>

--- a/src/admin/pages/ContentType/Context/index.tsx
+++ b/src/admin/pages/ContentType/Context/index.tsx
@@ -13,29 +13,19 @@ export const CollectionContextProvider: React.FC<{ children: React.ReactNode }> 
   const getCollection = (id: string, config?: SWRConfiguration): SWRResponse =>
     useSWR(
       `/collections/${id}`,
-      (url) =>
-        api
-          .get<{ collection: Collection }>(url)
-          .then((res) => res.data.collection)
-          .catch((err) => Promise.reject(err.message)),
+      (url) => api.get<{ collection: Collection }>(url).then((res) => res.data.collection),
       config
     );
 
   const getCollections = (): SWRResponse =>
     useSWR('/collections', (url) =>
-      api
-        .get<{ collections: Collection[] }>(url)
-        .then((res) => res.data.collections)
-        .catch((err) => Promise.reject(err.message))
+      api.get<{ collections: Collection[] }>(url).then((res) => res.data.collections)
     );
 
   const createCollection: SWRMutationResponse = useSWRMutation(
     '/collections',
     async (url: string, { arg }: { arg: Record<string, any> }) => {
-      return api
-        .post<{ collection: Collection }>(url, arg)
-        .then((res) => res.data.collection)
-        .catch((err) => Promise.reject(err.message));
+      return api.post<{ collection: Collection }>(url, arg).then((res) => res.data.collection);
     }
   );
 
@@ -43,21 +33,14 @@ export const CollectionContextProvider: React.FC<{ children: React.ReactNode }> 
     useSWRMutation(
       `/collections/${id}`,
       async (url: string, { arg }: { arg: Record<string, any> }) => {
-        return api
-          .patch<{ collection: Collection }>(url, arg)
-          .then((res) => res.data)
-          .catch((err) => Promise.reject(err.message));
+        return api.patch<{ collection: Collection }>(url, arg).then((res) => res.data);
       }
     );
 
   const getFields = (slug: string, config?: SWRConfiguration): SWRResponse =>
     useSWR(
       `/collections/${slug}/fields`,
-      (url) =>
-        api
-          .get<{ fields: Field[] }>(url)
-          .then((res) => res.data.fields)
-          .catch((err) => Promise.reject(err.message)),
+      (url) => api.get<{ fields: Field[] }>(url).then((res) => res.data.fields),
       config
     );
 

--- a/src/admin/pages/ContentType/Edit/CreateField/Context/index.tsx
+++ b/src/admin/pages/ContentType/Edit/CreateField/Context/index.tsx
@@ -9,10 +9,7 @@ const Context = createContext({} as FieldContext);
 export const FieldContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const createField = (slug: string): SWRMutationResponse =>
     useSWRMutation(`/collections/${slug}/fields`, async (url: string, { arg }: { arg: string }) => {
-      return api
-        .post<{ field: Field }>(url, arg)
-        .then((res) => res.data.field)
-        .catch((err) => Promise.reject(err.message));
+      return api.post<{ field: Field }>(url, arg).then((res) => res.data.field);
     });
 
   return (

--- a/src/admin/pages/ContentType/index.tsx
+++ b/src/admin/pages/ContentType/index.tsx
@@ -7,25 +7,18 @@ import { CollectionContextProvider, useCollection } from '@admin/pages/ContentTy
 import buildColumns from '@admin/utilities/buildColumns';
 import { Button, Stack } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
-import { useSnackbar } from 'notistack';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 const ContentTypePage: React.FC = () => {
   const { localizedLabel } = useDocumentInfo();
   const { t } = useTranslation();
   const { getCollections } = useCollection();
-  const { enqueueSnackbar } = useSnackbar();
-  const { data, error } = getCollections();
+  const { data } = getCollections();
 
   const fields = [{ field: 'collection', label: t('name'), type: Type.Text }];
 
   const columns = buildColumns(fields);
-
-  useEffect(() => {
-    if (error === undefined) return;
-    enqueueSnackbar(error, { variant: 'error' });
-  }, [error]);
 
   return (
     <Stack rowGap={3}>

--- a/src/admin/pages/Login/Context/index.tsx
+++ b/src/admin/pages/Login/Context/index.tsx
@@ -11,10 +11,7 @@ export const LoginContextProvider: React.FC<{ children: React.ReactNode }> = ({ 
     useSWR(
       '/project_settings',
       (url) =>
-        api
-          .get<{ projectSetting: ProjectSetting }>(url)
-          .then((res) => res.data.projectSetting)
-          .catch((err) => Promise.reject(err.message)),
+        api.get<{ projectSetting: ProjectSetting }>(url).then((res) => res.data.projectSetting),
       config
     );
 

--- a/src/admin/pages/Login/index.tsx
+++ b/src/admin/pages/Login/index.tsx
@@ -1,6 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Box, Button, FormHelperText, InputLabel, Stack, TextField } from '@mui/material';
-import { useSnackbar } from 'notistack';
 import React, { useEffect } from 'react';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -14,9 +13,8 @@ import { LoginContextProvider, useLogin } from './Context';
 const LoginPage: React.FC = () => {
   const navigate = useNavigate();
   const { t } = useTranslation();
-  const { enqueueSnackbar } = useSnackbar();
   const { login } = useAuth();
-  const { data: token, trigger, isMutating, error } = login();
+  const { data: token, trigger, isMutating } = login();
   const { getProjectSetting } = useLogin();
   const { data: projectSetting } = getProjectSetting();
 
@@ -33,11 +31,6 @@ const LoginPage: React.FC = () => {
     if (token === undefined) return;
     navigate('/admin/collections');
   }, [token]);
-
-  useEffect(() => {
-    if (error === undefined) return;
-    enqueueSnackbar(error, { variant: 'error' });
-  }, [error]);
 
   const onSubmit: SubmitHandler<FormValues> = (form: FormValues) => {
     trigger(form);

--- a/src/admin/pages/Project/Context/index.tsx
+++ b/src/admin/pages/Project/Context/index.tsx
@@ -14,19 +14,13 @@ export const ProjectSettingContextProvider: React.FC<{ children: React.ReactNode
     useSWR(
       '/project_settings',
       (url) =>
-        api
-          .get<{ projectSetting: ProjectSetting }>(url)
-          .then((res) => res.data.projectSetting)
-          .catch((err) => Promise.reject(err.message)),
+        api.get<{ projectSetting: ProjectSetting }>(url).then((res) => res.data.projectSetting),
       config
     );
 
   const updateProjectSetting = (): SWRMutationResponse =>
     useSWRMutation('/project_settings', async (url: string, { arg }: { arg: string }) => {
-      return api
-        .patch(url, arg)
-        .then((res) => res.data)
-        .catch((err) => Promise.reject(err.message));
+      return api.patch(url, arg).then((res) => res.data);
     });
 
   return (

--- a/src/admin/pages/Project/index.tsx
+++ b/src/admin/pages/Project/index.tsx
@@ -18,15 +18,10 @@ const ProjectPage: React.FC = () => {
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();
   const { getProjectSetting, updateProjectSetting } = useProjectSetting();
-  const { data: projectSetting, error: getProjectSettingError } = getProjectSetting({
+  const { data: projectSetting } = getProjectSetting({
     suspense: true,
   });
-  const {
-    data: updatedProjectSetting,
-    trigger,
-    isMutating,
-    error: updateProjectSettingError,
-  } = updateProjectSetting();
+  const { data: updatedProjectSetting, trigger, isMutating } = updateProjectSetting();
   const {
     control,
     handleSubmit,
@@ -35,16 +30,6 @@ const ProjectPage: React.FC = () => {
     defaultValues: { name: projectSetting.name },
     resolver: yupResolver(updateProjectSettingSchema()),
   });
-
-  useEffect(() => {
-    if (getProjectSettingError === undefined) return;
-    enqueueSnackbar(getProjectSettingError, { variant: 'error' });
-  }, [getProjectSettingError]);
-
-  useEffect(() => {
-    if (updateProjectSettingError === undefined) return;
-    enqueueSnackbar(updateProjectSettingError, { variant: 'error' });
-  }, [updateProjectSettingError]);
 
   useEffect(() => {
     if (updatedProjectSetting === undefined) return;

--- a/src/admin/pages/Role/Context/index.tsx
+++ b/src/admin/pages/Role/Context/index.tsx
@@ -9,76 +9,47 @@ const Context = createContext({} as RoleContext);
 
 export const RoleContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const getRoles = () =>
-    useSWR('/roles', (url) =>
-      api
-        .get<{ roles: Role[] }>(url)
-        .then((res) => res.data.roles)
-        .catch((err) => Promise.reject(err.message))
-    );
+    useSWR('/roles', (url) => api.get<{ roles: Role[] }>(url).then((res) => res.data.roles));
 
   const getRole = (id: string, config?: SWRConfiguration) =>
     useSWR(
       `/roles/${id}`,
-      (url) =>
-        api
-          .get<{ role: Role }>(url)
-          .then((res) => res.data.role)
-          .catch((err) => Promise.reject(err.message)),
+      (url) => api.get<{ role: Role }>(url).then((res) => res.data.role),
       config
     );
 
   const createRole = (): SWRMutationResponse =>
     useSWRMutation(`/roles`, async (url: string, { arg }: { arg: string }) => {
-      return api
-        .post<{ role: Role }>(url, arg)
-        .then((res) => res.data.role)
-        .catch((err) => Promise.reject(err.message));
+      return api.post<{ role: Role }>(url, arg).then((res) => res.data.role);
     });
 
   const updateRole = (id: string): SWRMutationResponse =>
     useSWRMutation(`/roles/${id}`, async (url: string, { arg }: { arg: string }) => {
-      return api
-        .patch(url, arg)
-        .then((res) => res.data)
-        .catch((err) => Promise.reject(err.message));
+      return api.patch(url, arg).then((res) => res.data);
     });
 
   const getCollections = (config?: SWRConfiguration): SWRResponse =>
     useSWR(
       '/collections',
-      (url) =>
-        api
-          .get<{ collections: Collection[] }>(url)
-          .then((res) => res.data.collections)
-          .catch((err) => Promise.reject(err.message)),
+      (url) => api.get<{ collections: Collection[] }>(url).then((res) => res.data.collections),
       config
     );
 
   const getPermissions = (id: string, config?: SWRConfiguration): SWRResponse =>
     useSWR(
       `/roles/${id}/permissions`,
-      (url) =>
-        api
-          .get<{ permissions: Permission[] }>(url)
-          .then((res) => res.data.permissions)
-          .catch((err) => Promise.reject(err.message)),
+      (url) => api.get<{ permissions: Permission[] }>(url).then((res) => res.data.permissions),
       config
     );
 
   const createPermission = (id: string): SWRMutationResponse =>
     useSWRMutation(`/roles/${id}/permissions`, async (url: string, { arg }: { arg: string }) => {
-      return api
-        .post<{ permission: Permission }>(url, arg)
-        .then((res) => res.data.permission)
-        .catch((err) => Promise.reject(err.message));
+      return api.post<{ permission: Permission }>(url, arg).then((res) => res.data.permission);
     });
 
   const deletePermission = (id: string, permissionId: string): SWRMutationResponse =>
     useSWRMutation(`/roles/${id}/permissions/${permissionId}`, async (url: string, { arg }) => {
-      return api
-        .delete(url, arg)
-        .then((res) => res.data)
-        .catch((err) => Promise.reject(err.message));
+      return api.delete(url, arg).then((res) => res.data);
     });
 
   return (

--- a/src/admin/pages/Role/index.tsx
+++ b/src/admin/pages/Role/index.tsx
@@ -7,16 +7,14 @@ import { RoleContextProvider, useRole } from '@admin/pages/Role/Context';
 import buildColumns from '@admin/utilities/buildColumns';
 import { Button, Stack } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
-import { useSnackbar } from 'notistack';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 const RolePage: React.FC = () => {
   const { t } = useTranslation();
   const { localizedLabel } = useDocumentInfo();
   const { getRoles } = useRole();
-  const { enqueueSnackbar } = useSnackbar();
-  const { data, error } = getRoles();
+  const { data } = getRoles();
 
   const fields = [
     { field: 'name', label: t('name'), type: Type.Text },
@@ -25,11 +23,6 @@ const RolePage: React.FC = () => {
   ];
 
   const columns = buildColumns(fields);
-
-  useEffect(() => {
-    if (error === undefined) return;
-    enqueueSnackbar(error, { variant: 'error' });
-  }, [error]);
 
   return (
     <Stack rowGap={3}>

--- a/src/admin/pages/User/Context/index.tsx
+++ b/src/admin/pages/User/Context/index.tsx
@@ -9,48 +9,29 @@ const Context = createContext({} as UserContext);
 
 export const UserContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const getUsers = () =>
-    useSWR('/users', (url) =>
-      api
-        .get<{ users: User[] }>(url)
-        .then((res) => res.data.users)
-        .catch((err) => Promise.reject(err.message))
-    );
+    useSWR('/users', (url) => api.get<{ users: User[] }>(url).then((res) => res.data.users));
 
   const getUser = (id: string, config?: SWRConfiguration) =>
     useSWR(
       `/users/${id}`,
-      (url) =>
-        api
-          .get<{ user: User }>(url)
-          .then((res) => res.data.user)
-          .catch((err) => Promise.reject(err.message)),
+      (url) => api.get<{ user: User }>(url).then((res) => res.data.user),
       config
     );
 
   const createUser = (): SWRMutationResponse =>
     useSWRMutation(`/users`, async (url: string, { arg }: { arg: string }) => {
-      return api
-        .post<{ user: User }>(url, arg)
-        .then((res) => res.data.user)
-        .catch((err) => Promise.reject(err.message));
+      return api.post<{ user: User }>(url, arg).then((res) => res.data.user);
     });
 
   const updateUser = (id: string): SWRMutationResponse =>
     useSWRMutation(`/users/${id}`, async (url: string, { arg }: { arg: string }) => {
-      return api
-        .patch(url, arg)
-        .then((res) => res.data)
-        .catch((err) => Promise.reject(err.message));
+      return api.patch(url, arg).then((res) => res.data);
     });
 
   const getRoles = (config?: SWRConfiguration) =>
     useSWR(
       '/roles',
-      (url) =>
-        api
-          .get<{ roles: Role[] }>(url)
-          .then((res) => res.data.roles)
-          .catch((err) => Promise.reject(err.message)),
+      (url) => api.get<{ roles: Role[] }>(url).then((res) => res.data.roles),
       config
     );
 

--- a/src/admin/pages/User/index.tsx
+++ b/src/admin/pages/User/index.tsx
@@ -1,7 +1,6 @@
 import { Button, Stack } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
-import { useSnackbar } from 'notistack';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { User } from '../../../shared/types';
 import RouterLink from '../../components/elements/Link';
@@ -17,8 +16,7 @@ const UserPage: React.FC = () => {
   const { localizedLabel } = useDocumentInfo();
   const { t } = useTranslation();
   const { getUsers } = useUser();
-  const { enqueueSnackbar } = useSnackbar();
-  const { data, error } = getUsers();
+  const { data } = getUsers();
 
   const fields = [
     { field: 'userName', label: t('user_name'), type: Type.Text },
@@ -45,11 +43,6 @@ const UserPage: React.FC = () => {
       <Cell colIndex={i} type={fields[i].type} rowData={row} cellData={data} />
     )
   );
-
-  useEffect(() => {
-    if (error === undefined) return;
-    enqueueSnackbar(error, { variant: 'error' });
-  }, [error]);
 
   return (
     <Stack rowGap={3}>

--- a/src/admin/pages/collections/Context/index.tsx
+++ b/src/admin/pages/collections/Context/index.tsx
@@ -12,58 +12,37 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
     // Fetching data that depends on fields.
     useSWR(
       () => `/collections/${slug}/contents`,
-      (url) =>
-        api
-          .get<{ contents: unknown[] }>(url)
-          .then((res) => res.data.contents)
-          .catch((err) => Promise.reject(err.message)),
+      (url) => api.get<{ contents: unknown[] }>(url).then((res) => res.data.contents),
       config
     );
 
   const getContent = (slug: string, id: string, config?: SWRConfiguration): SWRResponse =>
     useSWR(
       `/collections/${slug}/contents/${id}`,
-      (url) =>
-        api
-          .get<{ content: unknown }>(url)
-          .then((res) => res.data.content)
-          .catch((err) => Promise.reject(err.message)),
+      (url) => api.get<{ content: unknown }>(url).then((res) => res.data.content),
       config
     );
 
   const getFields = (slug: string, config?: SWRConfiguration): SWRResponse =>
     useSWR(
       `/collections/${slug}/fields`,
-      (url) =>
-        api
-          .get<{ fields: Field[] }>(url)
-          .then((res) => res.data.fields)
-          .catch((err) => Promise.reject(err.message)),
+      (url) => api.get<{ fields: Field[] }>(url).then((res) => res.data.fields),
       config
     );
 
   const getPreviewContents = (slug: string): SWRMutationResponse =>
     useSWRMutation(`/collections/${slug}/contents`, async (url: string, { arg }) => {
-      return api
-        .get<{ contents: unknown[] }>(url, arg)
-        .then((res) => res.data.contents)
-        .catch((err) => Promise.reject(err.message));
+      return api.get<{ contents: unknown[] }>(url, arg).then((res) => res.data.contents);
     });
 
   const createContent = (slug: string): SWRMutationResponse =>
     useSWRMutation(`/collections/${slug}/contents`, async (url: string, { arg }) => {
-      return api
-        .post<{ content: unknown }>(url, arg)
-        .then((res) => res.data.content)
-        .catch((err) => Promise.reject(err.message));
+      return api.post<{ content: unknown }>(url, arg).then((res) => res.data.content);
     });
 
   const updateContent = (slug: string, id: string): SWRMutationResponse =>
     useSWRMutation(`/collections/${slug}/contents/${id}`, async (url: string, { arg }) => {
-      return api
-        .patch<{ content: unknown }>(url, arg)
-        .then((res) => res.data)
-        .catch((err) => Promise.reject(err.message));
+      return api.patch<{ content: unknown }>(url, arg).then((res) => res.data);
     });
 
   return (

--- a/src/admin/pages/collections/Edit/index.tsx
+++ b/src/admin/pages/collections/Edit/index.tsx
@@ -1,7 +1,7 @@
-import { Button, Stack, useTheme } from '@mui/material';
+import { Button, Stack } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
 import { useSnackbar } from 'notistack';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -14,16 +14,14 @@ import ApiPreview from '../ApiPreview';
 import { Props } from './types';
 
 const EditPage: React.FC<Props> = ({ collection }) => {
-  const [drawerOpen, setDrawerOpen] = useState(false);
   const { id } = useParams();
-  const theme = useTheme();
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();
   const { hasPermission } = useAuth();
   const navigate = useNavigate();
   const { getContent, getFields, createContent, updateContent } = useContent();
-  const { data: metaFields, error: getFieldsError } = getFields(collection.collection);
-  const { data: content, error: getContentError } = getContent(collection.collection, id);
+  const { data: metaFields } = getFields(collection.collection);
+  const { data: content } = getContent(collection.collection, id);
   const {
     data: createdContent,
     trigger: createTrigger,
@@ -53,16 +51,6 @@ const EditPage: React.FC<Props> = ({ collection }) => {
     if (content === undefined) return;
     setDefaultValue(content);
   }, [content]);
-
-  useEffect(() => {
-    if (getFieldsError === undefined) return;
-    enqueueSnackbar(getFieldsError, { variant: 'error' });
-  }, [getFieldsError]);
-
-  useEffect(() => {
-    if (getContentError === undefined) return;
-    enqueueSnackbar(getContentError, { variant: 'error' });
-  }, [getContentError]);
 
   useEffect(() => {
     if (createdContent === undefined) return;

--- a/src/admin/pages/collections/List/Default.tsx
+++ b/src/admin/pages/collections/List/Default.tsx
@@ -8,7 +8,6 @@ import buildColumns from '@admin/utilities/buildColumns';
 import { Button } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
 import { Stack } from '@mui/system';
-import { useSnackbar } from 'notistack';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ApiPreview from '../ApiPreview';
@@ -18,10 +17,9 @@ import { Props } from './types';
 const DefaultListPage: React.FC<Props> = ({ collection }) => {
   const [columns, setColumns] = useState<Column[]>([]);
   const { t } = useTranslation();
-  const { enqueueSnackbar } = useSnackbar();
   const { getContents, getFields } = useContent();
-  const { data: metaFields, error: getFieldsError } = getFields(collection.collection);
-  const { data: contents, error: getContentsError } = getContents(collection.collection);
+  const { data: metaFields } = getFields(collection.collection);
+  const { data: contents } = getContents(collection.collection);
 
   useEffect(() => {
     if (metaFields === undefined) return;
@@ -31,16 +29,6 @@ const DefaultListPage: React.FC<Props> = ({ collection }) => {
     ));
     setColumns(columns);
   }, [metaFields]);
-
-  useEffect(() => {
-    if (getFieldsError === undefined) return;
-    enqueueSnackbar(getFieldsError, { variant: 'error' });
-  }, [getFieldsError]);
-
-  useEffect(() => {
-    if (getContentsError === undefined) return;
-    enqueueSnackbar(getContentsError, { variant: 'error' });
-  }, [getContentsError]);
 
   return (
     <Stack rowGap={3}>

--- a/src/admin/pages/collections/List/Singleton.tsx
+++ b/src/admin/pages/collections/List/Singleton.tsx
@@ -15,8 +15,8 @@ const SingletonPage: React.FC<Props> = ({ collection }) => {
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();
   const { getContents, getFields, createContent, updateContent } = useContent();
-  const { data: metaFields, error: getFieldsError } = getFields(collection.collection);
-  const { data: contents, error: getContentsError } = getContents(collection.collection);
+  const { data: metaFields } = getFields(collection.collection);
+  const { data: contents } = getContents(collection.collection);
   const {
     data: createdContent,
     trigger: createTrigger,
@@ -47,16 +47,6 @@ const SingletonPage: React.FC<Props> = ({ collection }) => {
     setContent(contents?.[0]);
     setDefaultValue(contents?.[0]);
   }, [contents]);
-
-  useEffect(() => {
-    if (getFieldsError === undefined) return;
-    enqueueSnackbar(getFieldsError, { variant: 'error' });
-  }, [getFieldsError]);
-
-  useEffect(() => {
-    if (getContentsError === undefined) return;
-    enqueueSnackbar(getContentsError, { variant: 'error' });
-  }, [getContentsError]);
 
   useEffect(() => {
     if (createdContent === undefined) return;


### PR DESCRIPTION
## 何をしたか
- SWRConfigureをrootに追加
- SWRのエラーをグローバルでハンドリングする
  - axiosのcatch節を削除
  - 各画面ごとのスナックバー表示は冗長なので