### PR TITLE
role_admin_access から admin_access にリネーム

### DIFF
--- a/src/server/controllers/authentications.ts
+++ b/src/server/controllers/authentications.ts
@@ -63,7 +63,7 @@ const fetchMe = async (params: { email?: string; id?: number }): Promise<MeUser>
   const user = await database
     .select('u.id', 'u.user_name', 'u.password', 'u.api_key', {
       role_id: 'r.id',
-      role_admin_access: 'r.admin_access',
+      admin_access: 'r.admin_access',
     })
     .from('superfast_users AS u')
     .join('superfast_roles AS r', 'r.id', 'u.superfast_role_id')


### PR DESCRIPTION
## 何をしたか
- role_admin_access から admin_access にリネーム
  - 以下での対応漏れ
  - https://github.com/superfastcms/superfast/pull/332/files#diff-c0e53713a102e7c10ba9281a589109b584a1561627fb44db76836f923047e280R77