### PR TITLE
コンテンツ管理のNo dataの表示条件を変更した

### DIFF
--- a/src/admin/components/elements/Table/Cell/index.tsx
+++ b/src/admin/components/elements/Table/Cell/index.tsx
@@ -18,7 +18,7 @@ const Cell: React.FC<Props> = (props) => {
   }
 
   const sanitizedCellData = () => {
-    if (cellData === '') {
+    if (colIndex === 0 && (!cellData || String(cellData).trim() === '')) {
       return 'No data';
     }
 


### PR DESCRIPTION
## 何をしたか
- 先頭かつ null または空文字の場合に No data を表示する
  - 全カラムに表示されていたため