### PR TITLE
コンテンツ管理のボタン表示の改善

### DIFF
--- a/src/admin/pages/collections/List/Default.tsx
+++ b/src/admin/pages/collections/List/Default.tsx
@@ -42,17 +42,18 @@ const DefaultListPage: React.FC<Props> = ({ collection }) => {
             <Grid>
               <h1>{collection.collection}</h1>
             </Grid>
-            <Grid>
-              <Button
-                variant="outlined"
-                startIcon={<AddOutlined />}
-                component={RouterLink}
-                disabled={!hasPermission(collection.collection, 'create')}
-                to="create"
-              >
-                {t('create_new')}
-              </Button>
-            </Grid>
+            {hasPermission(collection.collection, 'create') && (
+              <Grid>
+                <Button
+                  variant="outlined"
+                  startIcon={<AddOutlined />}
+                  component={RouterLink}
+                  to="create"
+                >
+                  {t('create_new')}
+                </Button>
+              </Grid>
+            )}
           </Grid>
         </Grid>
         <Grid container columnSpacing={2} alignItems="center">

--- a/src/admin/pages/collections/List/Singleton.tsx
+++ b/src/admin/pages/collections/List/Singleton.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import RenderFields from '../../../components/forms/RenderFields';
+import { useAuth } from '../../../components/utilities/Auth';
 import ComposeWrapper from '../../../components/utilities/ComposeWrapper';
 import { ContentContextProvider, useContent } from '../../../pages/collections/Context';
 import ApiPreview from '../ApiPreview';
@@ -12,6 +13,7 @@ import { Props } from './types';
 
 const SingletonPage: React.FC<Props> = ({ collection }) => {
   const [content, setContent] = useState(null);
+  const { hasPermission } = useAuth();
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();
   const { getContents, getFields, createContent, updateContent } = useContent();
@@ -85,7 +87,11 @@ const SingletonPage: React.FC<Props> = ({ collection }) => {
             <Button
               variant="contained"
               type="submit"
-              disabled={isCreateMutating || isUpdateMutating}
+              disabled={
+                !hasPermission(collection.collection, 'update') ||
+                isCreateMutating ||
+                isUpdateMutating
+              }
             >
               {t('update')}
             </Button>


### PR DESCRIPTION
## 何をしたか
- Singletonコレクションの更新ボタンは、更新権限がある人のみ表示する
- コンテンツ管理の新規登録ボタンは、登録権限がある人のみ表示する