### PR TITLE
APIのパーミッションを修正した

### DIFF
--- a/src/admin/components/utilities/Config/index.tsx
+++ b/src/admin/components/utilities/Config/index.tsx
@@ -2,6 +2,7 @@ import { Collection, Config } from '@shared/types';
 import React, { createContext, useContext } from 'react';
 import useSWR from 'swr';
 import api from '../../../utilities/api';
+import { useAuth } from '../Auth';
 
 type ContextType = {
   collections: Collection[];
@@ -14,8 +15,10 @@ export const ConfigProvider: React.FC<{ config: Config; children: React.ReactNod
   children,
   config,
 }) => {
+  const { user } = useAuth();
+
   const { data: collections } = useSWR(
-    '/collections',
+    user ? '/collections' : null,
     (url) => api.get<{ collections: Collection[] }>(url).then((res) => res.data.collections),
     { suspense: true }
   );

--- a/src/admin/index.tsx
+++ b/src/admin/index.tsx
@@ -17,28 +17,28 @@ const Loading = Loader(lazy(() => import('./components/elements/Loading')));
 const Index = () => (
   <>
     <Suspense fallback={<Loading />}>
-      <ConfigProvider
-        config={{
-          serverUrl: 'http://localhost:4000',
-        }}
-      >
-        <ColorModeProvider>
-          <ThemeProvider>
-            <Router>
-              <SnackbarProvider
-                maxSnack={3}
-                anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
-              >
-                <SWRConfigure>
-                  <AuthProvider>
+      <ColorModeProvider>
+        <ThemeProvider>
+          <Router>
+            <SnackbarProvider
+              maxSnack={3}
+              anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+            >
+              <SWRConfigure>
+                <AuthProvider>
+                  <ConfigProvider
+                    config={{
+                      serverUrl: 'http://localhost:4000',
+                    }}
+                  >
                     <Routes />
-                  </AuthProvider>
-                </SWRConfigure>
-              </SnackbarProvider>
-            </Router>
-          </ThemeProvider>
-        </ColorModeProvider>
-      </ConfigProvider>
+                  </ConfigProvider>
+                </AuthProvider>
+              </SWRConfigure>
+            </SnackbarProvider>
+          </Router>
+        </ThemeProvider>
+      </ColorModeProvider>
     </Suspense>
   </>
 );

--- a/src/server/controllers/authentications.ts
+++ b/src/server/controllers/authentications.ts
@@ -26,7 +26,7 @@ app.post(
 
 app.get(
   '/me',
-  permissionsHandler([{ collection: 'superfast_users', action: 'read' }]),
+  permissionsHandler(),
   asyncHandler(async (req: Request, res: Response) => {
     const user = await fetchMe({ id: req.userId });
     const token = toToken(user);

--- a/src/server/controllers/collections.ts
+++ b/src/server/controllers/collections.ts
@@ -8,7 +8,7 @@ const app = express();
 
 app.get(
   '/collections/:id',
-  permissionsHandler([{ collection: 'superfast_collections', action: 'read' }]),
+  permissionsHandler(),
   asyncHandler(async (req: Request, res: Response) => {
     const database = await getDatabase();
     const id = Number(req.params.id);
@@ -28,7 +28,7 @@ app.get(
 
 app.get(
   '/collections',
-  permissionsHandler([{ collection: 'superfast_collections', action: 'read' }]),
+  permissionsHandler(),
   asyncHandler(async (req: Request, res: Response) => {
     const database = await getDatabase();
     const collections = await database('superfast_collections').queryContext({

--- a/src/server/controllers/fields.ts
+++ b/src/server/controllers/fields.ts
@@ -3,13 +3,13 @@ import { Knex } from 'knex';
 import { Collection, Field } from '../../shared/types';
 import { getDatabase } from '../database/connection';
 import asyncHandler from '../middleware/asyncHandler';
-import permissionsHandler from '../middleware/permissionsHandler';
+import permissionsHandler, { collectionPermissionsHandler } from '../middleware/permissionsHandler';
 
 const app = express();
 
 app.get(
   '/collections/:slug/fields',
-  permissionsHandler([{ collection: 'superfast_fields', action: 'read' }]),
+  collectionPermissionsHandler('read'),
   asyncHandler(async (req: Request, res: Response) => {
     const database = await getDatabase();
     const slug = req.params.slug;

--- a/src/server/controllers/roles.ts
+++ b/src/server/controllers/roles.ts
@@ -106,7 +106,7 @@ app.delete(
 
 app.get(
   '/roles/:id/permissions',
-  permissionsHandler([{ collection: 'superfast_permissions', action: 'read' }]),
+  permissionsHandler(),
   asyncHandler(async (req: Request, res: Response) => {
     const database = await getDatabase();
     const id = req.params.id;

--- a/src/server/middleware/permissionsHandler.ts
+++ b/src/server/middleware/permissionsHandler.ts
@@ -7,7 +7,7 @@ import { getDatabase } from '../database/connection';
 export const collectionPermissionsHandler =
   (action: PermissionsAction) => async (req: Request, res: Response, next: NextFunction) => {
     if (!req.userId) {
-      next(new InvalidCredentialsException('invalid_user_credentials'));
+      return next(new InvalidCredentialsException('invalid_user_credentials'));
     }
 
     if (!req.adminAccess) {
@@ -34,7 +34,7 @@ const permissionsHandler =
   (permissions: { collection: string; action: PermissionsAction }[] = []) =>
   async (req: Request, res: Response, next: NextFunction) => {
     if (!req.userId) {
-      next(new InvalidCredentialsException('invalid_user_credentials'));
+      return next(new InvalidCredentialsException('invalid_user_credentials'));
     }
 
     if (!req.adminAccess && permissions.length > 0) {


### PR DESCRIPTION
## 何をしたか
- APIのパーミッションを修正した
  - システムテーブルへの権限がなくいくつかの機能が使えなくなったので
- ConfigProvider を AuthProvider の下位コンポーネントに移動
- 認証エラーによる例外発行時は、return して早期終了させる
  - `can not set headers after they are sent` への対応