### PR TITLE
コンテンツタイプフィールドはスネークケースを強制にした

### DIFF
--- a/src/admin/fields/schemas/collectionFields/createField.ts
+++ b/src/admin/fields/schemas/collectionFields/createField.ts
@@ -12,7 +12,7 @@ export const createField = (t: TFunction): ObjectSchema<FormValues> => {
   return yup.object().shape({
     field: yup
       .string()
-      .matches(/^[_0-9a-zA-Z]+$/, t('yup.custom.alphanumeric_and_underscore'))
+      .matches(/^[_0-9a-z]+$/, t('yup.custom.lower_case_alphanumerics_and_underscore'))
       .required()
       .max(60),
     label: yup.string().required().max(60),

--- a/src/lang/translations/en/translation.json
+++ b/src/lang/translations/en/translation.json
@@ -141,6 +141,7 @@
     "custom": {
       "alphanumeric": "Please enter single-byte alphanumeric characters.",
       "alphanumeric_and_underscore": "Please enter single-byte alphanumeric characters and underscore (_).",
+      "lower_case_alphanumerics_and_underscore": "Please enter single-byte lower-case alphanumeric characters and underscore (_).",
       "one_character": "Please enter at least 1 single-byte alphabetical character.",
       "one_number": "Please enter at least one one-byte number.",
       "one_special_character": "Please enter at least one symbol '@$! %*#?&'."

--- a/src/lang/translations/ja/translation.json
+++ b/src/lang/translations/ja/translation.json
@@ -141,6 +141,7 @@
     "custom": {
       "alphanumeric": "半角英数字で入力してください",
       "alphanumeric_and_underscore": "半角英数字およびアンダースコア（_）で入力してください",
+      "lower_case_alphanumerics_and_underscore": "半角小文字英数字およびアンダースコア（_）で入力してください",
       "one_character": "半角英字1文字以上入力してください",
       "one_number": "半角数字1文字以上入力してください",
       "one_special_character": "記号「@$!%*#?&」1文字以上入力してください"

--- a/src/server/controllers/collections.ts
+++ b/src/server/controllers/collections.ts
@@ -12,10 +12,7 @@ app.get(
   asyncHandler(async (req: Request, res: Response) => {
     const database = getDatabase();
     const id = Number(req.params.id);
-    const collection = await database('superfast_collections')
-      .queryContext({ toCamel: false })
-      .where('id', id)
-      .first();
+    const collection = await database('superfast_collections').where('id', id).first();
 
     res.json({
       collection: {
@@ -31,9 +28,7 @@ app.get(
   permissionsHandler(),
   asyncHandler(async (req: Request, res: Response) => {
     const database = getDatabase();
-    const collections = await database('superfast_collections').queryContext({
-      toCamel: false,
-    });
+    const collections = await database('superfast_collections');
 
     res.json({ collections: collections });
   })
@@ -52,9 +47,7 @@ app.post(
           table.timestamps(true, true);
         });
 
-        const collections = await tx('superfast_collections')
-          .queryContext({ toCamel: false })
-          .insert(req.body, '*');
+        const collections = await tx('superfast_collections').insert(req.body, '*');
 
         await tx('superfast_fields').insert({
           collection: req.body.collection,

--- a/src/server/controllers/contents.ts
+++ b/src/server/controllers/contents.ts
@@ -11,7 +11,7 @@ app.get(
   asyncHandler(async (req: Request, res: Response) => {
     const database = getDatabase();
     const slug = req.params.slug;
-    const contents = await database(slug).queryContext({ toCamel: false });
+    const contents = await database(slug);
 
     res.json({
       contents: contents,
@@ -26,7 +26,7 @@ app.get(
     const database = getDatabase();
     const slug = req.params.slug;
     const id = req.params.id;
-    const content = await database(slug).queryContext({ toCamel: false }).where('id', id).first();
+    const content = await database(slug).where('id', id).first();
 
     res.json({
       content: content,
@@ -41,7 +41,7 @@ app.post(
     const database = getDatabase();
     const slug = req.params.slug;
 
-    const content = await database(slug).queryContext({ toCamel: false }).insert(req.body);
+    const content = await database(slug).insert(req.body);
 
     res.json({
       content: content,

--- a/src/server/controllers/fields.ts
+++ b/src/server/controllers/fields.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response } from 'express';
 import { Knex } from 'knex';
+import { camelCase } from 'lodash';
 import { Collection, Field } from '../../shared/types';
 import { getDatabase } from '../database/connection';
 import asyncHandler from '../middleware/asyncHandler';
@@ -14,6 +15,10 @@ app.get(
     const database = getDatabase();
     const slug = req.params.slug;
     const fields = await database('superfast_fields').where('collection', slug);
+
+    fields.forEach((field) => {
+      field.field = camelCase(field.field);
+    });
 
     res.json({
       fields: fields,

--- a/src/server/controllers/roles.ts
+++ b/src/server/controllers/roles.ts
@@ -119,9 +119,7 @@ app.post(
       role_id: id,
     };
 
-    const permissions = await database<Permission>('superfast_permissions')
-      .queryContext({ toSnake: true })
-      .insert(data, 'id');
+    const permissions = await database<Permission>('superfast_permissions').insert(data, 'id');
 
     res.json({
       permission: permissions[0],

--- a/src/server/controllers/users.ts
+++ b/src/server/controllers/users.ts
@@ -68,9 +68,7 @@ app.post(
     const database = getDatabase();
     req.body.password = await oneWayHash(req.body.password);
 
-    const users = await database<User>('superfast_users')
-      .queryContext({ toSnake: true })
-      .insert(req.body, 'id');
+    const users = await database<User>('superfast_users').insert(req.body, 'id');
 
     res.json({
       user: users[0],
@@ -89,10 +87,7 @@ app.patch(
       req.body.password = await oneWayHash(req.body.password);
     }
 
-    await database('superfast_users')
-      .queryContext({ toSnake: true })
-      .where('id', id)
-      .update(req.body);
+    await database('superfast_users').where('id', id).update(req.body);
 
     res.status(204).end();
   })

--- a/src/server/database/connection.ts
+++ b/src/server/database/connection.ts
@@ -20,18 +20,13 @@ export const getDatabase = (): Knex => {
       directory: migrationFiles,
       loadExtensions: [process.env.MIGRATE_EXTENSIONS],
     },
-    wrapIdentifier(value, wrapIdentifier, queryContext) {
-      // Key Type Conversion for Post Data.
-      if (queryContext && queryContext.toSnake) {
-        return wrapIdentifier(snakeCase(value));
-      }
-      return value;
+    wrapIdentifier(value, wrapIdentifier) {
+      // Convert field to snake case.
+      const snakedValue = snakeCase(value) || value;
+      return wrapIdentifier(snakedValue);
     },
-    postProcessResponse: (result, queryContext) => {
-      // Key Type Conversion for Json Response.
-      if (queryContext && !queryContext.toCamel) {
-        return result;
-      }
+    postProcessResponse: (result) => {
+      // Convert field to camel case.
       return camelcaseKeys(result);
     },
   };

--- a/src/server/repositories/base.ts
+++ b/src/server/repositories/base.ts
@@ -49,16 +49,13 @@ export abstract class BaseRepository<T> implements AbstractRepository<T> {
   }
 
   async create(item: Omit<T, 'id'>): Promise<T> {
-    const [output] = await this.queryBuilder
-      .queryContext({ toSnake: true })
-      .insert(item)
-      .returning('id');
+    const [output] = await this.queryBuilder.insert(item).returning('id');
 
     return output as Promise<T>;
   }
 
   update(id: number, item: Partial<T>): Promise<boolean> {
-    return this.queryBuilder.where('id', id).queryContext({ toSnake: true }).update(item);
+    return this.queryBuilder.where('id', id).update(item);
   }
 
   delete(id: number): Promise<boolean> {


### PR DESCRIPTION
## なぜか
コンテンツタイプで動的に入れたフィールドは、プレーンなまま扱う方針になっていた。そのため、APIによってリテラルケースが異なり取り扱いが難しくなっていた。

ex)
システムフィールドの `created_at` もスネークスケースになってしまう。
```
{
    "contents": [
        {
            "id": 1,
            "created_at": "2023-03-17 22:55:33",
            "updated_at": "2023-03-17 22:55:33",
            "shop_Name": "Next新宿店",
            "phoneNumber": "03-1234-5678"
        }
    ]
}
```

## 何をしたか
- コンテンツタイプフィールドは、登録時にスネークケースを強制にした
- queryContextを削除して、無条件でリクエスト時にはスネークケース、レスポンス時にはキャメルケースで返す仕様にした