### PR TITLE
データ削除後に「レコードが見つかりません」のスナックバーを表示させない

### DIFF
--- a/src/admin/pages/ContentType/Context/index.tsx
+++ b/src/admin/pages/ContentType/Context/index.tsx
@@ -10,8 +10,8 @@ const Context = createContext({} as CollectionContext);
 export const CollectionContextProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const getCollection = (id: string, config?: SWRConfiguration): SWRResponse =>
-    useSWR(
+  const getCollection = (id: string, config?: SWRConfiguration): SWRMutationResponse =>
+    useSWRMutation(
       `/collections/${id}`,
       (url) => api.get<{ collection: Collection }>(url).then((res) => res.data.collection),
       config
@@ -39,7 +39,7 @@ export const CollectionContextProvider: React.FC<{ children: React.ReactNode }> 
 
   const getFields = (slug: string, config?: SWRConfiguration): SWRResponse =>
     useSWR(
-      `/collections/${slug}/fields`,
+      () => `/collections/${slug}/fields`,
       (url) => api.get<{ fields: Field[] }>(url).then((res) => res.data.fields),
       config
     );

--- a/src/admin/pages/ContentType/Context/types.ts
+++ b/src/admin/pages/ContentType/Context/types.ts
@@ -3,7 +3,7 @@ import { SWRMutationResponse } from 'swr/mutation';
 import { Collection, Field } from '../../../../shared/types';
 
 export type CollectionContext = {
-  getCollection: (id: string, config?: SWRConfiguration) => SWRResponse<Collection>;
+  getCollection: (id: string, config?: SWRConfiguration) => SWRMutationResponse<Collection>;
   getCollections: () => SWRResponse<Collection[]>;
   createCollection: SWRMutationResponse<Collection, any, Record<string, any>, any>;
   updateCollection: (id: string) => SWRMutationResponse<void, any, Record<string, any>, any>;

--- a/src/admin/pages/ContentType/Edit/index.tsx
+++ b/src/admin/pages/ContentType/Edit/index.tsx
@@ -20,7 +20,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Field } from '../../../../shared/types';
 import logger from '../../../../utilities/logger';
-import HeaderDeleteButton from '../../../components/elements/DeleteHeaderButton';
+import DeleteHeaderButton from '../../../components/elements/DeleteHeaderButton';
 import Loading from '../../../components/elements/Loading';
 import ComposeWrapper from '../../../components/utilities/ComposeWrapper';
 import { useDocumentInfo } from '../../../components/utilities/DocumentInfo';
@@ -172,7 +172,7 @@ const EditPage: React.FC = () => {
           </Grid>
           <Grid container columnSpacing={2} alignItems="center">
             <Grid>
-              <HeaderDeleteButton id={id} slug="collections" onSuccess={handleDeletionSuccess} />
+              <DeleteHeaderButton id={id} slug="collections" onSuccess={handleDeletionSuccess} />
             </Grid>
             <Grid>
               <Button variant="contained" type="submit" disabled={isMutating}>

--- a/src/admin/pages/ContentType/Edit/index.tsx
+++ b/src/admin/pages/ContentType/Edit/index.tsx
@@ -14,11 +14,11 @@ import {
 } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
 import { useSnackbar } from 'notistack';
-import React, { Suspense, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Field } from '../../../../shared/types';
+import { Collection, Field } from '../../../../shared/types';
 import logger from '../../../../utilities/logger';
 import DeleteHeaderButton from '../../../components/elements/DeleteHeaderButton';
 import Loading from '../../../components/elements/Loading';
@@ -46,25 +46,36 @@ const EditPage: React.FC = () => {
   const { enqueueSnackbar } = useSnackbar();
   const { localizedLabel } = useDocumentInfo();
   const { getCollection, updateCollection, getFields, updateFields } = useCollection();
-  const { data: meta } = getCollection(id, { suspense: true });
-  const { data: fields, mutate } = getFields(meta.collection, { suspense: true });
+  const { data: meta, trigger: getCollectionTrigger } = getCollection(id);
+  const { data: fields, mutate } = getFields(meta?.collection);
   const { trigger, isMutating } = updateCollection(id);
   const { trigger: updateFieldsTrigger } = updateFields();
   const {
     control,
     handleSubmit,
+    setValue,
     formState: { errors },
   } = useForm<FormValues>({
-    defaultValues: {
-      hidden: Boolean(meta.hidden),
-      singleton: Boolean(meta.singleton),
-      statusField: meta.statusField || '',
-      draftValue: meta.draftValue || '',
-      publishValue: meta.publishValue || '',
-      archiveValue: meta.archiveValue || '',
-    },
     resolver: yupResolver(updateCollectionSchema()),
   });
+
+  useEffect(() => {
+    const getCollection = async () => {
+      const collection = await getCollectionTrigger();
+      setDefaultValue(collection);
+    };
+
+    getCollection();
+  }, []);
+
+  const setDefaultValue = (collection: Collection) => {
+    setValue('hidden', Boolean(collection.hidden));
+    setValue('singleton', Boolean(collection.singleton));
+    setValue('statusField', collection.statusField || '');
+    setValue('draftValue', collection.draftValue || '');
+    setValue('publishValue', collection.publishValue || '');
+    setValue('archiveValue', collection.archiveValue || '');
+  };
 
   useEffect(() => {
     if (fields && fields.length) {
@@ -139,8 +150,12 @@ const EditPage: React.FC = () => {
     onCloseMenu();
   };
 
+  if (!meta || !fields) {
+    return <Loading />;
+  }
+
   return (
-    <Suspense fallback={<Loading />}>
+    <>
       <CreateField
         slug={meta.collection}
         openState={createFieldOpen}
@@ -304,7 +319,7 @@ const EditPage: React.FC = () => {
                   {...field}
                   type="text"
                   fullWidth
-                  error={errors.draftValue !== undefined}
+                  error={errors.publishValue !== undefined}
                 />
               )}
             />
@@ -320,7 +335,7 @@ const EditPage: React.FC = () => {
                   {...field}
                   type="text"
                   fullWidth
-                  error={errors.draftValue !== undefined}
+                  error={errors.archiveValue !== undefined}
                 />
               )}
             />
@@ -328,7 +343,7 @@ const EditPage: React.FC = () => {
           </Grid>
         </Grid>
       </Stack>
-    </Suspense>
+    </>
   );
 };
 

--- a/src/admin/pages/Role/Context/index.tsx
+++ b/src/admin/pages/Role/Context/index.tsx
@@ -11,11 +11,9 @@ export const RoleContextProvider: React.FC<{ children: React.ReactNode }> = ({ c
   const getRoles = () =>
     useSWR('/roles', (url) => api.get<{ roles: Role[] }>(url).then((res) => res.data.roles));
 
-  const getRole = (id: string, config?: SWRConfiguration) =>
-    useSWR(
-      `/roles/${id}`,
-      (url) => api.get<{ role: Role }>(url).then((res) => res.data.role),
-      config
+  const getRole = (id: string): SWRMutationResponse =>
+    useSWRMutation(`/roles/${id}`, (url) =>
+      api.get<{ role: Role }>(url).then((res) => res.data.role)
     );
 
   const createRole = (): SWRMutationResponse =>

--- a/src/admin/pages/Role/Context/types.ts
+++ b/src/admin/pages/Role/Context/types.ts
@@ -4,7 +4,7 @@ import { Collection, Permission, Role } from '../../../../shared/types';
 
 export type RoleContext = {
   getRoles: () => SWRResponse<Role[]>;
-  getRole: (id: string, config?: SWRConfiguration) => SWRResponse<Role>;
+  getRole: (id: string) => SWRMutationResponse<Role>;
   createRole: () => SWRMutationResponse<Role, any, Record<string, any>, any>;
   updateRole: (id: string) => SWRMutationResponse<void, any, Record<string, any>, any>;
   getCollections: (config?: SWRConfiguration) => SWRResponse<Collection[]>;

--- a/src/admin/pages/User/Context/index.tsx
+++ b/src/admin/pages/User/Context/index.tsx
@@ -11,11 +11,9 @@ export const UserContextProvider: React.FC<{ children: React.ReactNode }> = ({ c
   const getUsers = () =>
     useSWR('/users', (url) => api.get<{ users: User[] }>(url).then((res) => res.data.users));
 
-  const getUser = (id: string, config?: SWRConfiguration) =>
-    useSWR(
-      `/users/${id}`,
-      (url) => api.get<{ user: User }>(url).then((res) => res.data.user),
-      config
+  const getUser = (id: string): SWRMutationResponse =>
+    useSWRMutation(`/users/${id}`, (url) =>
+      api.get<{ user: User }>(url).then((res) => res.data.user)
     );
 
   const createUser = (): SWRMutationResponse =>

--- a/src/admin/pages/User/Context/types.ts
+++ b/src/admin/pages/User/Context/types.ts
@@ -4,7 +4,7 @@ import { Role, User } from '../../../../shared/types';
 
 export type UserContext = {
   getUsers: () => SWRResponse<User[]>;
-  getUser: (id: string, config?: SWRConfiguration) => SWRResponse<User>;
+  getUser: (id: string) => SWRMutationResponse<User>;
   getRoles: (config?: SWRConfiguration) => SWRResponse<Role[]>;
   createUser: () => SWRMutationResponse<User, any, Record<string, any>, any>;
   updateUser: (id: string) => SWRMutationResponse<void, any, Record<string, any>, any>;

--- a/src/admin/pages/collections/Context/index.tsx
+++ b/src/admin/pages/collections/Context/index.tsx
@@ -26,8 +26,8 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
       config
     );
 
-  const getContent = (slug: string, id: string, config?: SWRConfiguration): SWRResponse =>
-    useSWR(
+  const getContent = (slug: string, id: string, config?: SWRConfiguration): SWRMutationResponse =>
+    useSWRMutation(
       id ? `/collections/${slug}/contents/${id}` : null,
       (url) => api.get<{ content: unknown }>(url).then((res) => res.data.content),
       config

--- a/src/admin/pages/collections/Context/types.ts
+++ b/src/admin/pages/collections/Context/types.ts
@@ -9,7 +9,7 @@ export type ContentContext = {
     slug: string,
     config?: SWRConfiguration
   ) => SWRResponse<any>;
-  getContent: (slug: string, id: string, config?: SWRConfiguration) => SWRResponse<any>;
+  getContent: (slug: string, id: string, config?: SWRConfiguration) => SWRMutationResponse<any>;
   getFields: (slug: string, config?: SWRConfiguration) => SWRResponse<Field[]>;
   getPreviewContents: (slug: string) => SWRMutationResponse<any[]>;
   createContent: (slug: string) => SWRMutationResponse<unknown>;

--- a/src/admin/pages/collections/Edit/index.tsx
+++ b/src/admin/pages/collections/Edit/index.tsx
@@ -23,7 +23,7 @@ const EditPage: React.FC<Props> = ({ collection }) => {
   const navigate = useNavigate();
   const { getContent, getFields, createContent, updateContent } = useContent();
   const { data: metaFields } = getFields(collection.collection, { suspense: true });
-  const { data: content } = getContent(collection.collection, id);
+  const { data: content, trigger: getContentTrigger } = getContent(collection.collection, id);
   const { trigger: createTrigger, isMutating: isCreateMutating } = createContent(
     collection.collection
   );
@@ -38,6 +38,10 @@ const EditPage: React.FC<Props> = ({ collection }) => {
     setValue,
     formState: { errors },
   } = useForm();
+
+  useEffect(() => {
+    if (id) getContentTrigger();
+  }, []);
 
   const setDefaultValue = (fields: Field[]) => {
     fields

--- a/src/server/controllers/collections.ts
+++ b/src/server/controllers/collections.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response } from 'express';
 import { Field } from 'shared/types';
+import { RecordNotFoundException } from '../../shared/exceptions/database/recordNotFound';
 import asyncHandler from '../middleware/asyncHandler';
 import permissionsHandler from '../middleware/permissionsHandler';
 import CollectionsRepository from '../repositories/collections';
@@ -16,6 +17,7 @@ app.get(
     const repository = new CollectionsRepository();
 
     const collection = await repository.readOne(id);
+    if (!collection) throw new RecordNotFoundException('record_not_found');
 
     res.json({
       collection: {

--- a/src/server/controllers/roles.ts
+++ b/src/server/controllers/roles.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response } from 'express';
+import { RecordNotFoundException } from '../../shared/exceptions/database/recordNotFound';
 import { UnprocessableEntityException } from '../../shared/exceptions/unprocessableEntity';
 import asyncHandler from '../middleware/asyncHandler';
 import permissionsHandler from '../middleware/permissionsHandler';
@@ -28,6 +29,7 @@ app.get(
     const repository = new RolesRepository();
 
     const role = await repository.readOne(id);
+    if (!role) throw new RecordNotFoundException('record_not_found');
 
     res.json({ role });
   })

--- a/src/server/controllers/users.ts
+++ b/src/server/controllers/users.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import express, { Request, Response } from 'express';
 import env from '../../env';
+import { RecordNotFoundException } from '../../shared/exceptions/database/recordNotFound';
 import { InvalidCredentialsException } from '../../shared/exceptions/invalidCredentials';
 import { UnprocessableEntityException } from '../../shared/exceptions/unprocessableEntity';
 import asyncHandler from '../middleware/asyncHandler';
@@ -37,14 +38,11 @@ app.get(
     const repository = new UsersRepository();
 
     const user = await repository.readOneWithRole({ id });
+    if (!user) throw new RecordNotFoundException('record_not_found');
 
-    if (user) {
-      res.json({
-        user: payload(user),
-      });
-    } else {
-      res.status(400).end();
-    }
+    res.json({
+      user: payload(user),
+    });
   })
 );
 


### PR DESCRIPTION
## 何をしたか
- データ削除後に「レコードが見つかりません」のスナックバーを表示させない
  - 対象画面：コンテンツ管理、コンテンツタイプ、ユーザー、ロール
- リファクタ
  - 単一レコードの取得に失敗した場合、Exceptionをスローする