### PR TITLE
エラーレスポンス受信時に、詳細メッセージ(message)が含まれている場合はスナックバーに表示する

### DIFF
--- a/src/admin/components/utilities/SWRConfigure/index.tsx
+++ b/src/admin/components/utilities/SWRConfigure/index.tsx
@@ -3,6 +3,7 @@ import { useSnackbar } from 'notistack';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SWRConfig } from 'swr';
+import { ApiError } from '../../../../shared/types';
 import { Props } from './types';
 
 const SWRConfigure: React.FC<Props> = ({ children }) => {
@@ -14,11 +15,15 @@ const SWRConfigure: React.FC<Props> = ({ children }) => {
       value={{
         onError: (err) => {
           if (err instanceof AxiosError) {
-            const data = err.response.data;
-            if (data?.code) {
-              enqueueSnackbar(t(`error.${data.code}` as unknown as TemplateStringsArray), {
-                variant: 'error',
-              });
+            const apiError = err.response.data as ApiError;
+            if (apiError) {
+              let message = `${t(`error.${apiError.code}` as unknown as TemplateStringsArray)}`;
+              if (apiError.extensions?.message) {
+                message += `(${apiError.extensions.message})`;
+              }
+              enqueueSnackbar(message, { variant: 'error' });
+            } else {
+              enqueueSnackbar(t('error.internal_server_error'), { variant: 'error' });
             }
           }
         },

--- a/src/server/middleware/errorHandler.ts
+++ b/src/server/middleware/errorHandler.ts
@@ -12,9 +12,12 @@ const errorHandler: ErrorRequestHandler = (
 ) => {
   logger.error(err);
 
-  const base = err as BaseException;
+  let base = err as BaseException;
   if (base?.status === undefined) {
-    return res.status(500).json({ status: 500, code: 'internal_server_error' });
+    base = new BaseException(500, 'internal_server_error');
+    base.extensions = {
+      message: err.message,
+    };
   }
 
   if (process.env.NODE_ENV === 'development') {
@@ -23,7 +26,6 @@ const errorHandler: ErrorRequestHandler = (
       stack: err.stack,
     };
   }
-
   return res.status(base.status).json(base.toJson());
 };
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -27,6 +27,18 @@ export type MeUser = {
 export type AuthUser = Omit<MeUser, 'password'>;
 
 // /////////////////////////////////////
+// Error
+// /////////////////////////////////////
+
+export type ApiError = {
+  status: number;
+  code: string;
+  extensions?: {
+    message?: string;
+  };
+};
+
+// /////////////////////////////////////
 // Schema
 // /////////////////////////////////////
 


### PR DESCRIPTION
## 何をしたか
- 500エラー時に、エラーメッセージを `extensions.message` に詰める対応
- エラーレスポンス受信時に、上記メッセージが含まれている場合はスナックバーに表示する