### PR TITLE
webpack-bundle-analyzer を dependencies に移動

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "url-loader": "^4.1.1",
     "uuid": "^9.0.0",
     "webpack": "^5.75.0",
+    "webpack-bundle-analyzer": "^4.8.0",
     "webpack-dev-middleware": "^6.0.1",
     "webpack-hot-middleware": "^2.25.3",
     "webpack-node-externals": "^3.0.0",
@@ -152,8 +153,7 @@
     "prettier": "^2.7.1",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.3",
-    "webpack-bundle-analyzer": "^4.8.0"
+    "typescript": "^5.0.3"
   },
   "peerDependencies": {
     "path-to-regexp": "^6.2.1"


### PR DESCRIPTION
## 何をしたか
- webpack-bundle-analyzer を dependencies に移動
  - npm経由から取り込むと、利用してる webpackUtil で Cannot find module エラーが出る