### PR TITLE
webpack に source map 設定を追加

### DIFF
--- a/src/webpack/adminConfigure.ts
+++ b/src/webpack/adminConfigure.ts
@@ -6,6 +6,7 @@ import { pathList } from '../utilities/pathList.js';
 export const adminConfigure: webpack.Configuration = {
   mode: 'development',
   entry: pathList.admin('index.js'),
+  devtool: 'inline-source-map',
   output: {
     path: pathList.build('admin'),
     publicPath: '/admin/',

--- a/src/webpack/serverConfigure.ts
+++ b/src/webpack/serverConfigure.ts
@@ -4,6 +4,7 @@ import { pathList } from '../utilities/pathList.js';
 export const serverConfigure: webpack.Configuration = {
   mode: 'development',
   target: 'node',
+  devtool: 'inline-source-map',
   experiments: {
     outputModule: true,
   },


### PR DESCRIPTION
## 何をしたか
- webpack に source map 設定を追加
  - https://webpack.js.org/configuration/devtool/
  - 出力先の指定も不要なので inline-source-map にする