### PR TITLE
GitHub actionsにtype checkジョブを追加

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,6 +23,9 @@ jobs:
       - name: yarn install
         run: yarn install
 
+      - name: Type Check
+        run: yarn typecheck
+
       - name: Prettier
         run: yarn format
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,6 @@
     "skipLibCheck": true, // Ignore node_modules during type check.
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
-  }
+  },
+  "exclude": ["docs/**"]
 }


### PR DESCRIPTION
## 何をしたか
- GitHub actions に type check ジョブを追加
  - CI のみ docs 配下のモジュールエラーが検出されるので exclude に追加

## ref
- タイプチェックエラーの確認PR
  - https://github.com/superfastcms/superfast/pull/496