### PR TITLE
フィールドタイプも ComposeWrapper を使えるようにする

### DIFF
--- a/src/admin/components/forms/RenderFields/index.tsx
+++ b/src/admin/components/forms/RenderFields/index.tsx
@@ -4,10 +4,10 @@ import { Field } from '../../../../config/types.js';
 import { fieldTypes } from '../fieldTypes/index.js';
 import { Props } from './types.js';
 
-export const RenderFields: React.FC<Props> = ({ context, fields }) => {
+export const RenderFields: React.FC<Props> = ({ form, fields }) => {
   const {
     formState: { errors },
-  } = context;
+  } = form;
   const formFields = fields.filter((field) => !field.hidden);
 
   const invalidMessage = (field: string): string | null => {
@@ -27,7 +27,7 @@ export const RenderFields: React.FC<Props> = ({ context, fields }) => {
             <InputLabel htmlFor={meta.field} required={Boolean(meta.required)}>
               {meta.label}
             </InputLabel>
-            <FieldComponent context={context} field={meta} />
+            <FieldComponent form={form} field={meta} />
             <FormHelperText error>{invalidMessage(meta.field)}</FormHelperText>
           </Box>
         );

--- a/src/admin/components/forms/RenderFields/types.ts
+++ b/src/admin/components/forms/RenderFields/types.ts
@@ -2,6 +2,6 @@ import { FieldValues, UseFormReturn } from 'react-hook-form';
 import { Field } from '../../../../config/types.js';
 
 export type Props = {
-  context: UseFormReturn<FieldValues, any>;
+  form: UseFormReturn<FieldValues, any>;
   fields: Field[];
 };

--- a/src/admin/components/forms/fieldTypes/Boolean/index.tsx
+++ b/src/admin/components/forms/fieldTypes/Boolean/index.tsx
@@ -1,9 +1,9 @@
 import { Checkbox } from '@mui/material';
 import React from 'react';
 import { Controller } from 'react-hook-form';
-import { Props } from '../types';
+import { Props } from '../types.js';
 
-export const BooleanType: React.FC<Props> = ({ context: { control }, field: meta }) => {
+export const BooleanType: React.FC<Props> = ({ form: { control }, field: meta }) => {
   return (
     <Controller
       name={meta.field}

--- a/src/admin/components/forms/fieldTypes/DateTime/index.tsx
+++ b/src/admin/components/forms/fieldTypes/DateTime/index.tsx
@@ -7,10 +7,10 @@ import utc from 'dayjs/plugin/utc.js';
 import React from 'react';
 import { Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { Props } from '../types';
+import { Props } from '../types.js';
 
 export const DateTimeType: React.FC<Props> = ({
-  context: {
+  form: {
     register,
     control,
     formState: { errors },

--- a/src/admin/components/forms/fieldTypes/FileImage/index.tsx
+++ b/src/admin/components/forms/fieldTypes/FileImage/index.tsx
@@ -2,14 +2,13 @@ import { PhotoCamera } from '@mui/icons-material';
 import { Box, IconButton } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import useSWRMutation, { SWRMutationResponse } from 'swr/mutation';
-import { File } from '../../../../../config/types.js';
 import { logger } from '../../../../../utilities/logger.js';
-import { api } from '../../../../utilities/api.js';
+import { ContentContextProvider, useContent } from '../../../../pages/collections/Context/index.js';
+import { ComposeWrapper } from '../../../utilities/ComposeWrapper/index.js';
 import { Props } from '../types.js';
 
-export const FileImageType: React.FC<Props> = ({
-  context: { register, setValue, watch },
+const FileImageTypeImpl: React.FC<Props> = ({
+  form: { register, setValue, watch },
   field: meta,
 }) => {
   const { t } = useTranslation();
@@ -17,16 +16,7 @@ export const FileImageType: React.FC<Props> = ({
   const [content, setContent] = useState<string | null>(null);
   const [fileId, setFileId] = useState<string | null>(null);
 
-  const getFileImage = (id: string | null): SWRMutationResponse<{ file: File; raw: string }> =>
-    useSWRMutation(id ? `/files/${id}` : null, (url) =>
-      api.get<{ file: File; raw: string }>(url).then((res) => res.data)
-    );
-
-  const createFileImage = () =>
-    useSWRMutation(`/files`, async (url: string, { arg }: { arg: Record<string, any> }) => {
-      return api.post<{ file: File; raw: string }>(url, arg).then((res) => res.data);
-    });
-
+  const { getFileImage, createFileImage } = useContent();
   const { trigger: getFileImageTrigger } = getFileImage(fileId);
   const { trigger: createFileImageTrigger } = createFileImage();
 
@@ -101,3 +91,5 @@ export const FileImageType: React.FC<Props> = ({
     </Box>
   );
 };
+
+export const FileImageType = ComposeWrapper({ context: ContentContextProvider })(FileImageTypeImpl);

--- a/src/admin/components/forms/fieldTypes/Input/index.tsx
+++ b/src/admin/components/forms/fieldTypes/Input/index.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Props } from '../types.js';
 
 export const InputType: React.FC<Props> = ({
-  context: {
+  form: {
     register,
     formState: { errors },
   },

--- a/src/admin/components/forms/fieldTypes/InputMultiline/index.tsx
+++ b/src/admin/components/forms/fieldTypes/InputMultiline/index.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Props } from '../types.js';
 
 export const InputMultilineType: React.FC<Props> = ({
-  context: {
+  form: {
     register,
     formState: { errors },
   },

--- a/src/admin/components/forms/fieldTypes/InputRichTextMd/index.tsx
+++ b/src/admin/components/forms/fieldTypes/InputRichTextMd/index.tsx
@@ -6,7 +6,7 @@ import { SimpleMdeReact } from 'react-simplemde-editor';
 import { Props } from '../types.js';
 
 export const InputRichTextMdType: React.FC<Props> = ({
-  context: { control, register },
+  form: { control, register },
   field: meta,
 }) => {
   const { t } = useTranslation();

--- a/src/admin/components/forms/fieldTypes/SelectDropdown/index.tsx
+++ b/src/admin/components/forms/fieldTypes/SelectDropdown/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Props } from '../types';
 
 export const SelectDropdownType: React.FC<Props> = ({
-  context: { control, register },
+  form: { control, register },
   field: meta,
 }) => {
   const { t } = useTranslation();

--- a/src/admin/components/forms/fieldTypes/types.ts
+++ b/src/admin/components/forms/fieldTypes/types.ts
@@ -2,6 +2,6 @@ import { FieldValues, UseFormReturn } from 'react-hook-form';
 import { Field } from '../../../../config/types.js';
 
 export type Props = {
-  context: UseFormReturn<FieldValues, any>;
+  form: UseFormReturn<FieldValues, any>;
   field: Field;
 };

--- a/src/admin/pages/collections/Context/index.tsx
+++ b/src/admin/pages/collections/Context/index.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useMemo } from 'react';
 import useSWR, { SWRConfiguration, SWRResponse } from 'swr';
 import useSWRMutation, { SWRMutationResponse } from 'swr/mutation';
-import { Field } from '../../../../config/types.js';
+import { Field, File } from '../../../../config/types.js';
 import { api } from '../../../utilities/api.js';
 import { ContentContext } from './types.js';
 
@@ -59,6 +59,16 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
       }
     );
 
+  const getFileImage = (id: string | null): SWRMutationResponse<{ file: File; raw: string }> =>
+    useSWRMutation(id ? `/files/${id}` : null, (url) =>
+      api.get<{ file: File; raw: string }>(url).then((res) => res.data)
+    );
+
+  const createFileImage = () =>
+    useSWRMutation(`/files`, async (url: string, { arg }: { arg: Record<string, any> }) => {
+      return api.post<{ file: File; raw: string }>(url, arg).then((res) => res.data);
+    });
+
   const value = useMemo(
     () => ({
       getContents,
@@ -68,6 +78,8 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
       getPreviewContents,
       createContent,
       updateContent,
+      getFileImage,
+      createFileImage,
     }),
     [
       getContents,
@@ -77,6 +89,8 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
       getPreviewContents,
       createContent,
       updateContent,
+      getFileImage,
+      createFileImage,
     ]
   );
 

--- a/src/admin/pages/collections/Context/types.ts
+++ b/src/admin/pages/collections/Context/types.ts
@@ -1,6 +1,6 @@
 import { SWRConfiguration, SWRResponse } from 'swr';
 import { SWRMutationResponse } from 'swr/mutation';
-import { Field } from '../../../../config/types.js';
+import { Field, File } from '../../../../config/types.js';
 
 export type ContentContext = {
   getContents: (canFetch: boolean, slug: string, config?: SWRConfiguration) => SWRResponse<any[]>;
@@ -17,4 +17,11 @@ export type ContentContext = {
     slug: string,
     id: string
   ) => SWRMutationResponse<void, any, Record<string, any>, any>;
+  getFileImage: (id: string | null) => SWRMutationResponse<{ file: File; raw: string }>;
+  createFileImage: () => SWRMutationResponse<
+    { file: File; raw: string },
+    any,
+    Record<string, any>,
+    any
+  >;
 };

--- a/src/admin/pages/collections/Edit/index.tsx
+++ b/src/admin/pages/collections/Edit/index.tsx
@@ -139,7 +139,7 @@ const EditCollectionPageImpl: React.FC<Props> = ({ collection }) => {
       <Grid container columns={{ xs: 1, lg: 2 }}>
         <Grid xs={1}>
           <Stack rowGap={3}>
-            <RenderFields context={formContext} fields={metaFields || []} />
+            <RenderFields form={formContext} fields={metaFields || []} />
           </Stack>
         </Grid>
       </Grid>

--- a/src/admin/pages/collections/List/Singleton.tsx
+++ b/src/admin/pages/collections/List/Singleton.tsx
@@ -89,7 +89,7 @@ const SingletonPageImpl: React.FC<Props> = ({ collection }) => {
       <Grid container columns={{ xs: 1, lg: 2 }}>
         <Grid xs={1}>
           <Stack rowGap={3}>
-            <RenderFields context={formContext} fields={metaFields || []} />
+            <RenderFields form={formContext} fields={metaFields || []} />
           </Stack>
         </Grid>
       </Grid>


### PR DESCRIPTION
## 経緯
- 末端にあるフィールドタイプコンポーネント ( FileImageType ) で通信処理が書かれているが、再利用性がないので hook に寄せたい。
  - ただ現状、context というパラメータ名が重複していることで filedTypes で ComposeWrapper が使えない

## 何をしたか
- filedTypes のパラメータ名を context -> form にリネームした
- リファクタ
  - FileImageType の通信処理を hook に移動した