### PR TITLE
[Del] コンテンツタイプに OneToMany フィールドを追加する

### DIFF
--- a/src/admin/fields/schemas/collectionFields/listOneToMany/createListOneToMany.ts
+++ b/src/admin/fields/schemas/collectionFields/listOneToMany/createListOneToMany.ts
@@ -1,0 +1,29 @@
+import { TFunction } from 'i18next';
+import { ObjectSchema } from 'yup';
+import { yup } from '../../../yup.js';
+
+export type FormValues = {
+  field: string;
+  label: string;
+  required: boolean;
+  relatedCollection: string;
+  foreignKey: string;
+};
+
+export const createListOneToMany = (t: TFunction): ObjectSchema<FormValues> => {
+  return yup.object().shape({
+    field: yup
+      .string()
+      .matches(/^[_0-9a-z]+$/, t('yup.custom.lower_case_alphanumerics_and_underscore'))
+      .required()
+      .max(60),
+    label: yup.string().required().max(60),
+    required: yup.boolean().required(),
+    relatedCollection: yup.string().required(),
+    foreignKey: yup
+      .string()
+      .matches(/^[_0-9a-z]+$/, t('yup.custom.lower_case_alphanumerics_and_underscore'))
+      .required()
+      .max(60),
+  });
+};

--- a/src/admin/pages/ContentType/Edit/CreateField/Context/index.tsx
+++ b/src/admin/pages/ContentType/Edit/CreateField/Context/index.tsx
@@ -18,7 +18,7 @@ export const FieldContextProvider: React.FC<{ children: React.ReactNode }> = ({ 
       api.get<{ collections: Collection[] }>(url).then((res) => res.data.collections)
     );
 
-  const createRelations = () =>
+  const createRelation = () =>
     useSWRMutation(`/relations`, async (url: string, { arg }: { arg: Record<string, any> }) => {
       return api.post<{ relation: Relation }>(url, arg).then((res) => res.data.relation);
     });
@@ -27,9 +27,9 @@ export const FieldContextProvider: React.FC<{ children: React.ReactNode }> = ({ 
     () => ({
       createField,
       getCollections,
-      createRelations,
+      createRelation,
     }),
-    [createField, getCollections, createRelations]
+    [createField, getCollections, createRelation]
   );
 
   return <Context.Provider value={value}>{children}</Context.Provider>;

--- a/src/admin/pages/ContentType/Edit/CreateField/Context/index.tsx
+++ b/src/admin/pages/ContentType/Edit/CreateField/Context/index.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useMemo } from 'react';
 import useSWR, { SWRResponse } from 'swr';
 import useSWRMutation from 'swr/mutation';
-import { Collection, Field } from '../../../../../../config/types.js';
+import { Collection, Field, Relation } from '../../../../../../config/types.js';
 import { api } from '../../../../../utilities/api.js';
 import { FieldContext } from './types.js';
 
@@ -18,12 +18,18 @@ export const FieldContextProvider: React.FC<{ children: React.ReactNode }> = ({ 
       api.get<{ collections: Collection[] }>(url).then((res) => res.data.collections)
     );
 
+  const createRelations = () =>
+    useSWRMutation(`/relations`, async (url: string, { arg }: { arg: Record<string, any> }) => {
+      return api.post<{ relation: Relation }>(url, arg).then((res) => res.data.relation);
+    });
+
   const value = useMemo(
     () => ({
       createField,
       getCollections,
+      createRelations,
     }),
-    [createField, getCollections]
+    [createField, getCollections, createRelations]
   );
 
   return <Context.Provider value={value}>{children}</Context.Provider>;

--- a/src/admin/pages/ContentType/Edit/CreateField/Context/index.tsx
+++ b/src/admin/pages/ContentType/Edit/CreateField/Context/index.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useMemo } from 'react';
+import useSWR, { SWRResponse } from 'swr';
 import useSWRMutation from 'swr/mutation';
-import { Field } from '../../../../../../config/types.js';
+import { Collection, Field } from '../../../../../../config/types.js';
 import { api } from '../../../../../utilities/api.js';
 import { FieldContext } from './types.js';
 
@@ -12,11 +13,17 @@ export const FieldContextProvider: React.FC<{ children: React.ReactNode }> = ({ 
       return api.post<{ field: Field }>(url, arg).then((res) => res.data.field);
     });
 
+  const getCollections = (): SWRResponse =>
+    useSWR('/collections', (url) =>
+      api.get<{ collections: Collection[] }>(url).then((res) => res.data.collections)
+    );
+
   const value = useMemo(
     () => ({
       createField,
+      getCollections,
     }),
-    [createField]
+    [createField, getCollections]
   );
 
   return <Context.Provider value={value}>{children}</Context.Provider>;

--- a/src/admin/pages/ContentType/Edit/CreateField/Context/index.tsx
+++ b/src/admin/pages/ContentType/Edit/CreateField/Context/index.tsx
@@ -7,13 +7,10 @@ import { FieldContext } from './types.js';
 const Context = createContext({} as FieldContext);
 
 export const FieldContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const createField = (slug: string) =>
-    useSWRMutation(
-      `/collections/${slug}/fields`,
-      async (url: string, { arg }: { arg: Record<string, any> }) => {
-        return api.post<{ field: Field }>(url, arg).then((res) => res.data.field);
-      }
-    );
+  const createField = () =>
+    useSWRMutation(`/fields`, async (url: string, { arg }: { arg: Record<string, any> }) => {
+      return api.post<{ field: Field }>(url, arg).then((res) => res.data.field);
+    });
 
   const value = useMemo(
     () => ({

--- a/src/admin/pages/ContentType/Edit/CreateField/Context/types.ts
+++ b/src/admin/pages/ContentType/Edit/CreateField/Context/types.ts
@@ -1,6 +1,8 @@
+import { SWRResponse } from 'swr';
 import { SWRMutationResponse } from 'swr/mutation';
-import { Field } from '../../../../../../config/types.js';
+import { Collection, Field } from '../../../../../../config/types.js';
 
 export type FieldContext = {
   createField: () => SWRMutationResponse<Field, any, Record<string, any>, any>;
+  getCollections: () => SWRResponse<Collection[]>;
 };

--- a/src/admin/pages/ContentType/Edit/CreateField/Context/types.ts
+++ b/src/admin/pages/ContentType/Edit/CreateField/Context/types.ts
@@ -5,5 +5,5 @@ import { Collection, Field, Relation } from '../../../../../../config/types.js';
 export type FieldContext = {
   createField: () => SWRMutationResponse<Field, any, Record<string, any>, any>;
   getCollections: () => SWRResponse<Collection[]>;
-  createRelations: () => SWRMutationResponse<Relation, any, Record<string, any>, any>;
+  createRelation: () => SWRMutationResponse<Relation, any, Record<string, any>, any>;
 };

--- a/src/admin/pages/ContentType/Edit/CreateField/Context/types.ts
+++ b/src/admin/pages/ContentType/Edit/CreateField/Context/types.ts
@@ -1,8 +1,9 @@
 import { SWRResponse } from 'swr';
 import { SWRMutationResponse } from 'swr/mutation';
-import { Collection, Field } from '../../../../../../config/types.js';
+import { Collection, Field, Relation } from '../../../../../../config/types.js';
 
 export type FieldContext = {
   createField: () => SWRMutationResponse<Field, any, Record<string, any>, any>;
   getCollections: () => SWRResponse<Collection[]>;
+  createRelations: () => SWRMutationResponse<Relation, any, Record<string, any>, any>;
 };

--- a/src/admin/pages/ContentType/Edit/CreateField/Context/types.ts
+++ b/src/admin/pages/ContentType/Edit/CreateField/Context/types.ts
@@ -2,5 +2,5 @@ import { SWRMutationResponse } from 'swr/mutation';
 import { Field } from '../../../../../../config/types.js';
 
 export type FieldContext = {
-  createField: (slug: string) => SWRMutationResponse<Field, any, Record<string, any>, any>;
+  createField: () => SWRMutationResponse<Field, any, Record<string, any>, any>;
 };

--- a/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/Boolean/index.tsx
+++ b/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/Boolean/index.tsx
@@ -31,7 +31,7 @@ export const BooleanType: React.FC<Props> = (props) => {
   const { slug, expanded, handleChange, onEditing, onSuccess } = props;
   const { t } = useTranslation();
   const { createField } = useField();
-  const { trigger, isMutating } = createField(slug);
+  const { trigger, isMutating } = createField();
   const defaultValues = {
     field: '',
     label: '',

--- a/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/DateTime/index.tsx
+++ b/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/DateTime/index.tsx
@@ -31,7 +31,7 @@ export const DateTimeType: React.FC<Props> = (props) => {
   const { slug, expanded, handleChange, onEditing, onSuccess } = props;
   const { t } = useTranslation();
   const { createField } = useField();
-  const { trigger, isMutating } = createField(slug);
+  const { trigger, isMutating } = createField();
   const defaultValues = { field: '', label: '', required: false };
   const {
     control,

--- a/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/FileImage/index.tsx
+++ b/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/FileImage/index.tsx
@@ -31,7 +31,7 @@ export const FileImageType: React.FC<Props> = (props) => {
   const { slug, expanded, handleChange, onEditing, onSuccess } = props;
   const { t } = useTranslation();
   const { createField } = useField();
-  const { trigger, isMutating } = createField(slug);
+  const { trigger, isMutating } = createField();
   const defaultValues = { field: '', label: '', required: false };
   const {
     control,

--- a/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/Input/index.tsx
+++ b/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/Input/index.tsx
@@ -31,7 +31,7 @@ export const InputType: React.FC<Props> = (props) => {
   const { slug, expanded, handleChange, onEditing, onSuccess } = props;
   const { t } = useTranslation();
   const { createField } = useField();
-  const { trigger, isMutating } = createField(slug);
+  const { trigger, isMutating } = createField();
   const defaultValues = { field: '', label: '', required: false };
   const {
     control,

--- a/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/InputMultiline/index.tsx
+++ b/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/InputMultiline/index.tsx
@@ -31,7 +31,7 @@ export const InputMultilineType: React.FC<Props> = (props) => {
   const { slug, expanded, handleChange, onEditing, onSuccess } = props;
   const { t } = useTranslation();
   const { createField } = useField();
-  const { trigger, isMutating } = createField(slug);
+  const { trigger, isMutating } = createField();
   const defaultValues = { field: '', label: '', required: false };
   const {
     control,

--- a/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/InputRichTextMd/index.tsx
+++ b/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/InputRichTextMd/index.tsx
@@ -31,7 +31,7 @@ export const InputRichTextMdType: React.FC<Props> = (props) => {
   const { slug, expanded, handleChange, onEditing, onSuccess } = props;
   const { t } = useTranslation();
   const { createField } = useField();
-  const { trigger, isMutating } = createField(slug);
+  const { trigger, isMutating } = createField();
   const defaultValues = { field: '', label: '', required: false };
   const {
     control,

--- a/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/ListOneToMany/index.tsx
+++ b/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/ListOneToMany/index.tsx
@@ -17,9 +17,10 @@ import {
   Typography,
 } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2/Grid2';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { Field } from '../../../../../../../config/types.js';
 import { logger } from '../../../../../../../utilities/logger.js';
 import { shallowEqualObject } from '../../../../../../../utilities/shallowEqualObject.js';
 import {
@@ -28,15 +29,14 @@ import {
 } from '../../../../../../fields/schemas/collectionFields/listOneToMany/createListOneToMany.js';
 import { useField } from '../../Context/index.js';
 import { Props } from '../types.js';
-import { Field } from '../../../../../../../config/types.js';
 
 export const ListOneToManyType: React.FC<Props> = (props) => {
   const { slug, expanded, handleChange, onEditing, onSuccess } = props;
   const { t } = useTranslation();
-  const { createField, getCollections, createRelations } = useField();
+  const { createField, getCollections, createRelation } = useField();
   const { data: collections } = getCollections();
   const { trigger: createFieldTrigger, isMutating } = createField();
-  const { trigger: createRelationsTrigger } = createRelations();
+  const { trigger: createRelationTrigger } = createRelation();
   const defaultValues = {
     field: '',
     label: '',
@@ -85,7 +85,7 @@ export const ListOneToManyType: React.FC<Props> = (props) => {
         }),
       ]);
 
-      await createRelationsTrigger({
+      await createRelationTrigger({
         manyCollection: form.relatedCollection,
         manyField: form.foreignKey,
         oneCollection: slug,

--- a/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/ListOneToMany/index.tsx
+++ b/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/ListOneToMany/index.tsx
@@ -1,0 +1,226 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { SettingsEthernetOutlined } from '@mui/icons-material';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  FormHelperText,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import Grid from '@mui/material/Unstable_Grid2/Grid2';
+import React, { useEffect, useState } from 'react';
+import { Controller, SubmitHandler, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { logger } from '../../../../../../../utilities/logger.js';
+import { shallowEqualObject } from '../../../../../../../utilities/shallowEqualObject.js';
+import {
+  FormValues,
+  createListOneToMany as schema,
+} from '../../../../../../fields/schemas/collectionFields/listOneToMany/createListOneToMany.js';
+import { useField } from '../../Context/index.js';
+import { Props } from '../types.js';
+import { Field } from '../../../../../../../config/types.js';
+
+export const ListOneToManyType: React.FC<Props> = (props) => {
+  const { slug, expanded, handleChange, onEditing, onSuccess } = props;
+  const { t } = useTranslation();
+  const { createField, getCollections, createRelations } = useField();
+  const { data: collections } = getCollections();
+  const { trigger: createFieldTrigger, isMutating } = createField();
+  const { trigger: createRelationsTrigger } = createRelations();
+  const defaultValues = {
+    field: '',
+    label: '',
+    required: false,
+    relatedCollection: '',
+    foreignKey: '',
+  };
+  const {
+    control,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues,
+    resolver: yupResolver(schema(t)),
+  });
+
+  useEffect(() => {
+    watch((value) => {
+      const isEqualed = shallowEqualObject(defaultValues, value);
+      onEditing(!isEqualed);
+    });
+  }, [watch]);
+
+  const onSubmit: SubmitHandler<FormValues> = async (form: FormValues) => {
+    try {
+      const results = await Promise.all([
+        createFieldTrigger({
+          collection: slug,
+          field: form.field,
+          label: form.label,
+          interface: 'listOneToMany',
+          required: form.required,
+          readonly: false,
+          hidden: false,
+        }),
+        createFieldTrigger({
+          collection: form.relatedCollection,
+          field: form.foreignKey,
+          label: slug,
+          interface: 'selectDropdownManyToOne',
+          required: form.required,
+          readonly: false,
+          hidden: false,
+        }),
+      ]);
+
+      await createRelationsTrigger({
+        manyCollection: form.relatedCollection,
+        manyField: form.foreignKey,
+        oneCollection: slug,
+        oneField: form.field,
+      });
+      reset();
+      onSuccess(results[0] as Field);
+    } catch (e) {
+      logger.error(e);
+    }
+  };
+
+  return (
+    <Stack component="form" onSubmit={handleSubmit(onSubmit)}>
+      <Accordion
+        expanded={expanded}
+        square
+        disableGutters
+        onChange={() => handleChange('listOneToMany')}
+      >
+        <AccordionSummary aria-controls="panel-content" id="panel-header">
+          <Stack direction="row" columnGap={2}>
+            <Box display="flex" alignItems="center">
+              <SettingsEthernetOutlined />
+            </Box>
+            <Stack direction="column">
+              <Typography variant="subtitle1">{t('field_interface.list_o2m')}</Typography>
+              <Typography variant="caption">{t('field_interface.list_o2m_caption')}</Typography>
+            </Stack>
+          </Stack>
+        </AccordionSummary>
+        <AccordionDetails sx={{ py: 3 }}>
+          <Stack rowGap={3}>
+            <Grid container spacing={3} columns={{ xs: 1, sm: 4 }}>
+              <Grid xs={1} sm={2}>
+                <InputLabel required>{t('field')}</InputLabel>
+                <Controller
+                  name="field"
+                  control={control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      type="text"
+                      fullWidth
+                      placeholder={`${t('input-placeholder')} name`}
+                      error={errors.field !== undefined}
+                    />
+                  )}
+                />
+                <FormHelperText error>{errors.field?.message}</FormHelperText>
+              </Grid>
+              <Grid xs={1} sm={2}>
+                <InputLabel required>{t('label')}</InputLabel>
+                <Controller
+                  name="label"
+                  control={control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      type="text"
+                      fullWidth
+                      placeholder={`${t('input-placeholder')} ${t('name')}`}
+                      error={errors.label !== undefined}
+                    />
+                  )}
+                />
+                <FormHelperText error>{errors.label?.message}</FormHelperText>
+              </Grid>
+              <Grid xs={1} sm={2}>
+                <InputLabel required>{t('related_content')}</InputLabel>
+                <Controller
+                  name="relatedCollection"
+                  control={control}
+                  defaultValue={''}
+                  render={({ field }) => (
+                    <Select
+                      {...field}
+                      fullWidth
+                      defaultValue={''}
+                      error={errors.relatedCollection !== undefined}
+                    >
+                      <MenuItem value="">
+                        <em>None</em>
+                      </MenuItem>
+                      {collections &&
+                        collections
+                          .filter((collection) => collection.collection !== slug)
+                          .map((collection) => (
+                            <MenuItem value={collection.collection} key={collection.collection}>
+                              {collection.collection}
+                            </MenuItem>
+                          ))}
+                    </Select>
+                  )}
+                />
+                <FormHelperText error>{errors.relatedCollection?.message}</FormHelperText>
+              </Grid>
+              <Grid xs={1} sm={2}>
+                <InputLabel required>{t('foreign_key')}</InputLabel>
+                <Controller
+                  name="foreignKey"
+                  control={control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      type="text"
+                      fullWidth
+                      error={errors.foreignKey !== undefined}
+                    />
+                  )}
+                />
+                <FormHelperText error>{errors.foreignKey?.message}</FormHelperText>
+              </Grid>
+              <Grid xs={1} sm={2}>
+                <InputLabel htmlFor="field">{t('required_fields')}</InputLabel>
+                <Controller
+                  name="required"
+                  control={control}
+                  render={({ field }) => (
+                    <FormControlLabel
+                      {...field}
+                      label={t('required_at_creation')}
+                      control={<Checkbox />}
+                    />
+                  )}
+                />
+                <FormHelperText error>{errors.required?.message}</FormHelperText>
+              </Grid>
+            </Grid>
+            <Button variant="contained" type="submit" size="large" disabled={isMutating} fullWidth>
+              {t('save')}
+            </Button>
+          </Stack>
+        </AccordionDetails>
+      </Accordion>
+    </Stack>
+  );
+};

--- a/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/SelectDropdown/index.tsx
+++ b/src/admin/pages/ContentType/Edit/CreateField/fieldTypes/SelectDropdown/index.tsx
@@ -36,7 +36,7 @@ export const SelectDropdownType: React.FC<Props> = (props) => {
   const [state, setState] = useState(false);
   const { t } = useTranslation();
   const { createField } = useField();
-  const { trigger, isMutating } = createField(slug);
+  const { trigger, isMutating } = createField();
   const defaultValues = { field: '', label: '', required: false, choices: [] };
   const {
     control,

--- a/src/admin/pages/ContentType/Edit/CreateField/index.tsx
+++ b/src/admin/pages/ContentType/Edit/CreateField/index.tsx
@@ -12,6 +12,7 @@ import { FileImageType } from './fieldTypes/FileImage/index.js';
 import { InputType } from './fieldTypes/Input/index.js';
 import { InputMultilineType } from './fieldTypes/InputMultiline/index.js';
 import { InputRichTextMdType } from './fieldTypes/InputRichTextMd/index.js';
+import { ListOneToManyType } from './fieldTypes/ListOneToMany/index.js';
 import { SelectDropdownType } from './fieldTypes/SelectDropdown/index.js';
 import { Props } from './types.js';
 
@@ -144,42 +145,13 @@ const CreateFieldImpl: React.FC<Props> = ({ slug, openState, onSuccess, onClose 
             onEditing={handleEditing}
             onSuccess={handleAdditionSuccess}
           />
-          {/*
-          <FileType
+          <ListOneToManyType
             slug={slug}
-            expanded={fieldInterface === 'file'}
+            expanded={fieldInterface === 'listOneToMany'}
             handleChange={(field) => onSelectedFieldInterface(field)}
             onEditing={handleEditing}
             onSuccess={handleAdditionSuccess}
           />
-          <ListType
-            slug={slug}
-            expanded={fieldInterface === 'list'}
-            handleChange={(field) => onSelectedFieldInterface(field)}
-            onEditing={handleEditing}
-            onSuccess={handleAdditionSuccess}
-          />
-          <ListO2oType
-            slug={slug}
-            expanded={fieldInterface === 'listO2o'}
-            handleChange={(field) => onSelectedFieldInterface(field)}
-            onEditing={handleEditing}
-            onSuccess={handleAdditionSuccess}
-          />
-          <ListO2mType
-            slug={slug}
-            expanded={fieldInterface === 'listO2m'}
-            handleChange={(field) => onSelectedFieldInterface(field)}
-            onEditing={handleEditing}
-            onSuccess={handleAdditionSuccess}
-          />
-          <SelectDropdownM2oType
-            slug={slug}
-            expanded={fieldInterface === 'selectDropdownM2o'}
-            handleChange={(field) => onSelectedFieldInterface(field)}
-            onEditing={handleEditing}
-            onSuccess={handleAdditionSuccess}
-          /> */}
         </Box>
       </Drawer>
     </Box>

--- a/src/admin/pages/ContentType/Edit/EditField/fieldTypes/ListOneToMany/index.tsx
+++ b/src/admin/pages/ContentType/Edit/EditField/fieldTypes/ListOneToMany/index.tsx
@@ -1,0 +1,149 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import {
+  Button,
+  Checkbox,
+  FormControlLabel,
+  FormHelperText,
+  InputLabel,
+  Stack,
+  TextField,
+} from '@mui/material';
+import Grid from '@mui/material/Unstable_Grid2/Grid2.js';
+import React, { useEffect } from 'react';
+import { Controller, SubmitHandler, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { logger } from '../../../../../../../utilities/logger.js';
+import { shallowEqualObject } from '../../../../../../../utilities/shallowEqualObject.js';
+import {
+  FormValues,
+  updateInput as schema,
+} from '../../../../../../fields/schemas/collectionFields/input/updateInput.js';
+import { useField } from '../../Context/index.js';
+import { Props } from '../types.js';
+
+export const ListOneToManyType: React.FC<Props> = (props) => {
+  const { field: meta, onEditing, onSuccess } = props;
+  const { t } = useTranslation();
+  const { updateField } = useField();
+  const { trigger, isMutating } = updateField(meta.id);
+  const defaultValues = {
+    label: meta.label,
+    required: Boolean(meta.required),
+    readonly: Boolean(meta.readonly),
+    hidden: Boolean(meta.hidden),
+  };
+  const {
+    control,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues,
+    resolver: yupResolver(schema),
+  });
+
+  useEffect(() => {
+    watch((value) => {
+      const isEqualed = shallowEqualObject(defaultValues, value);
+      onEditing(!isEqualed);
+    });
+  }, [watch]);
+
+  const onSubmit: SubmitHandler<FormValues> = async (form: FormValues) => {
+    try {
+      const formData = {
+        label: form.label,
+        required: form.required,
+        readonly: form.readonly,
+        hidden: form.hidden,
+      };
+      await trigger(formData);
+      reset();
+      onSuccess({
+        ...meta,
+        ...formData,
+      });
+    } catch (e) {
+      logger.error(e);
+    }
+  };
+
+  return (
+    <Stack component="form" onSubmit={handleSubmit(onSubmit)} sx={{ p: 2 }}>
+      <Stack rowGap={3}>
+        <Grid container spacing={3} columns={{ xs: 1, sm: 4 }}>
+          <Grid xs={1} sm={2}>
+            <InputLabel required>{t('field')}</InputLabel>
+            <TextField type="text" fullWidth disabled defaultValue={meta.field} />
+          </Grid>
+          <Grid xs={1} sm={2}>
+            <InputLabel required>{t('label')}</InputLabel>
+            <Controller
+              name="label"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  type="text"
+                  fullWidth
+                  placeholder={`${t('input-placeholder')} ${t('name')}`}
+                  error={errors.label !== undefined}
+                />
+              )}
+            />
+            <FormHelperText error>{errors.label?.message}</FormHelperText>
+          </Grid>
+          <Grid xs={1} sm={2}>
+            <InputLabel htmlFor="field">{t('required_fields')}</InputLabel>
+            <Controller
+              name="required"
+              control={control}
+              render={({ field }) => (
+                <FormControlLabel
+                  {...field}
+                  label={t('required_at_creation')}
+                  control={<Checkbox checked={field.value} />}
+                />
+              )}
+            />
+            <FormHelperText error>{errors.required?.message}</FormHelperText>
+          </Grid>
+          <Grid xs={1} sm={2}>
+            <InputLabel htmlFor="field">{t('readonly')}</InputLabel>
+            <Controller
+              name="readonly"
+              control={control}
+              render={({ field }) => (
+                <FormControlLabel
+                  {...field}
+                  label={t('disable_editing_value')}
+                  control={<Checkbox checked={field.value} />}
+                />
+              )}
+            />
+            <FormHelperText error>{errors.readonly?.message}</FormHelperText>
+          </Grid>
+          <Grid xs={1} sm={2}>
+            <InputLabel htmlFor="field">{t('hidden')}</InputLabel>
+            <Controller
+              name="hidden"
+              control={control}
+              render={({ field }) => (
+                <FormControlLabel
+                  {...field}
+                  label={t('hidden_on_detail')}
+                  control={<Checkbox checked={field.value} />}
+                />
+              )}
+            />
+            <FormHelperText error>{errors.hidden?.message}</FormHelperText>
+          </Grid>
+        </Grid>
+        <Button variant="contained" type="submit" size="large" disabled={isMutating} fullWidth>
+          {t('save')}
+        </Button>
+      </Stack>
+    </Stack>
+  );
+};

--- a/src/admin/pages/ContentType/Edit/EditField/fieldTypes/SelectDropdownManyToOne/index.tsx
+++ b/src/admin/pages/ContentType/Edit/EditField/fieldTypes/SelectDropdownManyToOne/index.tsx
@@ -1,0 +1,149 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import {
+  Button,
+  Checkbox,
+  FormControlLabel,
+  FormHelperText,
+  InputLabel,
+  Stack,
+  TextField,
+} from '@mui/material';
+import Grid from '@mui/material/Unstable_Grid2/Grid2.js';
+import React, { useEffect } from 'react';
+import { Controller, SubmitHandler, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { logger } from '../../../../../../../utilities/logger.js';
+import { shallowEqualObject } from '../../../../../../../utilities/shallowEqualObject.js';
+import {
+  FormValues,
+  updateInput as schema,
+} from '../../../../../../fields/schemas/collectionFields/input/updateInput.js';
+import { useField } from '../../Context/index.js';
+import { Props } from '../types.js';
+
+export const SelectDropdownManyToOneType: React.FC<Props> = (props) => {
+  const { field: meta, onEditing, onSuccess } = props;
+  const { t } = useTranslation();
+  const { updateField } = useField();
+  const { trigger, isMutating } = updateField(meta.id);
+  const defaultValues = {
+    label: meta.label,
+    required: Boolean(meta.required),
+    readonly: Boolean(meta.readonly),
+    hidden: Boolean(meta.hidden),
+  };
+  const {
+    control,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues,
+    resolver: yupResolver(schema),
+  });
+
+  useEffect(() => {
+    watch((value) => {
+      const isEqualed = shallowEqualObject(defaultValues, value);
+      onEditing(!isEqualed);
+    });
+  }, [watch]);
+
+  const onSubmit: SubmitHandler<FormValues> = async (form: FormValues) => {
+    try {
+      const formData = {
+        label: form.label,
+        required: form.required,
+        readonly: form.readonly,
+        hidden: form.hidden,
+      };
+      await trigger(formData);
+      reset();
+      onSuccess({
+        ...meta,
+        ...formData,
+      });
+    } catch (e) {
+      logger.error(e);
+    }
+  };
+
+  return (
+    <Stack component="form" onSubmit={handleSubmit(onSubmit)} sx={{ p: 2 }}>
+      <Stack rowGap={3}>
+        <Grid container spacing={3} columns={{ xs: 1, sm: 4 }}>
+          <Grid xs={1} sm={2}>
+            <InputLabel required>{t('field')}</InputLabel>
+            <TextField type="text" fullWidth disabled defaultValue={meta.field} />
+          </Grid>
+          <Grid xs={1} sm={2}>
+            <InputLabel required>{t('label')}</InputLabel>
+            <Controller
+              name="label"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  type="text"
+                  fullWidth
+                  placeholder={`${t('input-placeholder')} ${t('name')}`}
+                  error={errors.label !== undefined}
+                />
+              )}
+            />
+            <FormHelperText error>{errors.label?.message}</FormHelperText>
+          </Grid>
+          <Grid xs={1} sm={2}>
+            <InputLabel htmlFor="field">{t('required_fields')}</InputLabel>
+            <Controller
+              name="required"
+              control={control}
+              render={({ field }) => (
+                <FormControlLabel
+                  {...field}
+                  label={t('required_at_creation')}
+                  control={<Checkbox checked={field.value} />}
+                />
+              )}
+            />
+            <FormHelperText error>{errors.required?.message}</FormHelperText>
+          </Grid>
+          <Grid xs={1} sm={2}>
+            <InputLabel htmlFor="field">{t('readonly')}</InputLabel>
+            <Controller
+              name="readonly"
+              control={control}
+              render={({ field }) => (
+                <FormControlLabel
+                  {...field}
+                  label={t('disable_editing_value')}
+                  control={<Checkbox checked={field.value} />}
+                />
+              )}
+            />
+            <FormHelperText error>{errors.readonly?.message}</FormHelperText>
+          </Grid>
+          <Grid xs={1} sm={2}>
+            <InputLabel htmlFor="field">{t('hidden')}</InputLabel>
+            <Controller
+              name="hidden"
+              control={control}
+              render={({ field }) => (
+                <FormControlLabel
+                  {...field}
+                  label={t('hidden_on_detail')}
+                  control={<Checkbox checked={field.value} />}
+                />
+              )}
+            />
+            <FormHelperText error>{errors.hidden?.message}</FormHelperText>
+          </Grid>
+        </Grid>
+        <Button variant="contained" type="submit" size="large" disabled={isMutating} fullWidth>
+          {t('save')}
+        </Button>
+      </Stack>
+    </Stack>
+  );
+};

--- a/src/admin/pages/ContentType/Edit/EditField/index.tsx
+++ b/src/admin/pages/ContentType/Edit/EditField/index.tsx
@@ -11,7 +11,9 @@ import { DateTimeType } from './fieldTypes/DateTime/index.js';
 import { InputType } from './fieldTypes/Input/index.js';
 import { InputMultilineType } from './fieldTypes/InputMultiline/index.js';
 import { InputRichTextMdType } from './fieldTypes/InputRichTextMd/input.js';
+import { ListOneToManyType } from './fieldTypes/ListOneToMany/index.js';
 import { SelectDropdownType } from './fieldTypes/SelectDropdown/index.js';
+import { SelectDropdownManyToOneType } from './fieldTypes/SelectDropdownManyToOne/index.js';
 import { Props } from './types.js';
 
 const EditFieldImpl: React.FC<Props> = ({ field, open, onSuccess, onClose }) => {
@@ -118,6 +120,20 @@ const EditFieldImpl: React.FC<Props> = ({ field, open, onSuccess, onClose }) => 
           )}
           {field.interface === 'dateTime' && (
             <DateTimeType field={field} onEditing={handleEditing} onSuccess={handleEditedSuccess} />
+          )}
+          {field.interface === 'listOneToMany' && (
+            <ListOneToManyType
+              field={field}
+              onEditing={handleEditing}
+              onSuccess={handleEditedSuccess}
+            />
+          )}
+          {field.interface === 'selectDropdownManyToOne' && (
+            <SelectDropdownManyToOneType
+              field={field}
+              onEditing={handleEditing}
+              onSuccess={handleEditedSuccess}
+            />
           )}
         </Box>
       </Drawer>

--- a/src/admin/pages/ContentType/Edit/index.tsx
+++ b/src/admin/pages/ContentType/Edit/index.tsx
@@ -126,8 +126,10 @@ const EditContentTypePageImpl: React.FC = () => {
   // Create Field
   // /////////////////////////////////////
 
-  const handleCreateFieldSuccess = () => {
+  const handleCreateFieldSuccess = (field: Field) => {
     setCreateFieldOpen(false);
+    fields.push(field);
+    mutate(fields);
   };
 
   // /////////////////////////////////////
@@ -164,7 +166,7 @@ const EditContentTypePageImpl: React.FC = () => {
       <CreateField
         slug={meta.collection}
         openState={createFieldOpen}
-        onSuccess={handleCreateFieldSuccess}
+        onSuccess={(field) => handleCreateFieldSuccess(field)}
         onClose={() => onToggleCreateField(false)}
       />
       {selectedField && (

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -59,17 +59,13 @@ export type Collection = {
 export type FieldInterface =
   | 'input'
   | 'inputMultiline'
-  // | 'inputRichTextHtml'
   | 'inputRichTextMd'
   | 'selectDropdown'
   | 'dateTime'
   | 'boolean'
-  // | 'file'
   | 'fileImage'
-  // | 'list'
-  // | 'listO2o' // one-to-one
-  // | 'listO2m' // one-to-many
-  // | 'selectDropdownM2o' // many-to-one
+  | 'listOneToMany'
+  | 'selectDropdownManyToOne'
   | 'selectDropdownStatus'; // public status
 export type FieldOption = {
   choices?: Choice[];

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -136,5 +136,5 @@ export type Relation = {
   manyCollection: string;
   manyField: string;
   oneCollection: string;
-  oneField: string | null;
+  oneField: string;
 } & PrimaryKey;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -135,3 +135,10 @@ export type File = {
   width: number | null;
   height: number | null;
 } & PrimaryKey;
+
+export type Relation = {
+  manyCollection: string;
+  manyField: string;
+  oneCollection: string;
+  oneField: string | null;
+} & PrimaryKey;

--- a/src/lang/translations/en/translation.json
+++ b/src/lang/translations/en/translation.json
@@ -90,6 +90,8 @@
   "default_value": "Default Value",
   "enabled": "Enabled",
   "disabled": "Disabled",
+  "related_content": "Related Content Type",
+  "foreign_key": "Foreign Key",
   "dialog": {
     "confirm_deletion_title": "Confirm deletion.",
     "confirm_deletion": "Once deleted, it cannot be restored. Are you sure you want to delete it?",

--- a/src/lang/translations/ja/translation.json
+++ b/src/lang/translations/ja/translation.json
@@ -90,6 +90,8 @@
   "default_value": "初期値",
   "enabled": "有効",
   "disabled": "無効",
+  "related_content": "関連コンテンツ",
+  "foreign_key": "外部キー",
   "dialog": {
     "confirm_deletion_title": "削除の確認",
     "confirm_deletion": "一度削除すると復元できません。削除してよろしいですか？",

--- a/src/server/controllers/collections.ts
+++ b/src/server/controllers/collections.ts
@@ -157,8 +157,8 @@ router.delete(
     await repository.transaction(async (tx) => {
       await tx.transaction.schema.dropTable(collection.collection);
       await repository.transacting(tx).delete(id);
-      await fieldsRepository.transacting(tx).deleteAll({ collection: collection.collection });
-      await permissionsRepository.transacting(tx).deleteAll({ collection: collection.collection });
+      await fieldsRepository.transacting(tx).deleteMany({ collection: collection.collection });
+      await permissionsRepository.transacting(tx).deleteMany({ collection: collection.collection });
 
       await tx
         .transaction('superfast_relations')

--- a/src/server/controllers/collections.ts
+++ b/src/server/controllers/collections.ts
@@ -184,8 +184,6 @@ router.delete(
       });
 
       for (let relation of manyRelations) {
-        if (relation.oneField === null) return;
-
         await fieldsRepository.transacting(tx).deleteMany({
           collection: relation.oneCollection,
           field: relation.oneField,

--- a/src/server/controllers/fields.ts
+++ b/src/server/controllers/fields.ts
@@ -34,19 +34,15 @@ router.get(
 );
 
 router.post(
-  '/collections/:slug/fields',
+  '/fields',
   permissionsHandler([{ collection: 'superfast_fields', action: 'create' }]),
   asyncHandler(async (req: Request, res: Response) => {
     const slug = req.params.slug;
     const repository = new FieldsRepository();
-    const collectionsRepository = new CollectionsRepository();
-
-    const collections = await collectionsRepository.read({ collection: slug });
 
     await repository.transaction(async (tx) => {
-      const result = await repository.transacting(tx).create(req.body);
-      const field = await repository.transacting(tx).readOne(result.id);
-      await tx.transaction.schema.alterTable(collections[0].collection, (table) => {
+      const field = await repository.transacting(tx).create(req.body);
+      await tx.transaction.schema.alterTable(field.collection, (table) => {
         addColumnToTable(field, table);
       });
 

--- a/src/server/controllers/fields.ts
+++ b/src/server/controllers/fields.ts
@@ -137,7 +137,6 @@ const addColumnToTable = (field: Field, table: Knex.CreateTableBuilder, alter: b
       column = table.string(field.field, 255).defaultTo('');
       break;
     case 'inputMultiline':
-    // case 'inputRichTextHtml':
     case 'inputRichTextMd':
       column = table.text(field.field);
       break;
@@ -157,11 +156,17 @@ const addColumnToTable = (field: Field, table: Knex.CreateTableBuilder, alter: b
         .references('id')
         .inTable('superfast_files');
       break;
+    case 'listOneToMany':
+      // noop
+      break;
+    case 'selectDropdownManyToOne':
+      column = table.integer(field.field).unsigned().index();
+      break;
     default:
       throw new InvalidPayloadException('unexpected_field_type_specified');
   }
 
-  if (alter) {
+  if (column && alter) {
     column.alter();
   }
 

--- a/src/server/controllers/relations.ts
+++ b/src/server/controllers/relations.ts
@@ -1,0 +1,32 @@
+import express, { Request, Response } from 'express';
+import { asyncHandler } from '../middleware/asyncHandler.js';
+import { permissionsHandler } from '../middleware/permissionsHandler.js';
+import { RelationsRepository } from '../repositories/relations.js';
+
+const router = express.Router();
+
+router.post(
+  '/relations',
+  permissionsHandler([{ collection: 'superfast_relations', action: 'create' }]),
+  asyncHandler(async (req: Request, res: Response) => {
+    const repository = new RelationsRepository();
+
+    await repository.transaction(async (tx) => {
+      const relation = await repository.transacting(tx).create(req.body);
+
+      await tx.transaction.schema.alterTable(relation.manyCollection, async (table) => {
+        const column = table
+          .integer(relation.manyField)
+          .references('id')
+          .inTable(relation.oneCollection);
+        column.alter();
+      });
+
+      res.json({
+        relation,
+      });
+    });
+  })
+);
+
+export const relations = router;

--- a/src/server/controllers/roles.ts
+++ b/src/server/controllers/roles.ts
@@ -86,7 +86,7 @@ router.delete(
 
     await repository.transaction(async (tx) => {
       await repository.transacting(tx).delete(id);
-      await permissionsRepository.transacting(tx).deleteAll({ roleId: id });
+      await permissionsRepository.transacting(tx).deleteMany({ roleId: id });
       res.status(204).end();
     });
   })

--- a/src/server/database/migrations/20230209234825_add-init-schema.ts
+++ b/src/server/database/migrations/20230209234825_add-init-schema.ts
@@ -65,7 +65,7 @@ export async function up(knex: Knex): Promise<void> {
     table.string('many_collection', 64).notNullable();
     table.string('many_field', 64).notNullable();
     table.string('one_collection', 64).notNullable();
-    table.string('one_field', 64);
+    table.string('one_field', 64).notNullable();
     table.timestamps(true, true);
   });
 

--- a/src/server/database/migrations/20230209234825_add-init-schema.ts
+++ b/src/server/database/migrations/20230209234825_add-init-schema.ts
@@ -66,11 +66,6 @@ export async function up(knex: Knex): Promise<void> {
     table.string('many_field', 64).notNullable();
     table.string('one_collection', 64).notNullable();
     table.string('one_field', 64);
-    table.string('one_collection_field', 64);
-    table.text('one_allowed_collections');
-    table.string('junction_field', 64);
-    table.string('sort_field', 64);
-    table.string('one_deselect_action', 255);
     table.timestamps(true, true);
   });
 

--- a/src/server/repositories/base.ts
+++ b/src/server/repositories/base.ts
@@ -49,7 +49,7 @@ export abstract class BaseRepository<T> implements AbstractRepository<T> {
   }
 
   async create(item: Omit<T, 'id'>): Promise<T> {
-    const [output] = await this.queryBuilder.insert(item).returning('id');
+    const [output] = await this.queryBuilder.insert(item).returning('*');
 
     return output as Promise<T>;
   }

--- a/src/server/repositories/base.ts
+++ b/src/server/repositories/base.ts
@@ -65,4 +65,8 @@ export abstract class BaseRepository<T> implements AbstractRepository<T> {
   delete(id: number): Promise<boolean> {
     return this.queryBuilder.where('id', id).del();
   }
+
+  deleteMany(data: Partial<T>): Promise<boolean> {
+    return this.queryBuilder.where(data).del();
+  }
 }

--- a/src/server/repositories/collections.ts
+++ b/src/server/repositories/collections.ts
@@ -16,7 +16,7 @@ export class CollectionsRepository extends BaseRepository<Collection> {
 
   async create(item: Omit<Collection, 'id'>): Promise<Collection> {
     await this.checkUniqueCollection(item.collection);
-    const [output] = await this.queryBuilder.insert(item).returning('id');
+    const [output] = await this.queryBuilder.insert(item).returning('*');
 
     return output as Promise<Collection>;
   }

--- a/src/server/repositories/fields.ts
+++ b/src/server/repositories/fields.ts
@@ -24,7 +24,7 @@ export class FieldsRepository extends BaseRepository<Field> {
 
   async create(item: Omit<Field, 'id'>): Promise<Field> {
     await this.checkUniqueField(item.collection, item.field);
-    const [output] = await this.queryBuilder.insert(item).returning('id');
+    const [output] = await this.queryBuilder.insert(item).returning('*');
 
     return output as Promise<Field>;
   }

--- a/src/server/repositories/fields.ts
+++ b/src/server/repositories/fields.ts
@@ -18,10 +18,6 @@ export class FieldsRepository extends BaseRepository<Field> {
     return this.queryBuilder.where(data).orderByRaw('sort ASC NULLS LAST');
   }
 
-  deleteAll(data: Partial<Field>): Promise<boolean> {
-    return this.queryBuilder.where(data).delete();
-  }
-
   async create(item: Omit<Field, 'id'>): Promise<Field> {
     await this.checkUniqueField(item.collection, item.field);
     const [output] = await this.queryBuilder.insert(item).returning('*');

--- a/src/server/repositories/permissions.ts
+++ b/src/server/repositories/permissions.ts
@@ -12,8 +12,4 @@ export class PermissionsRepository extends BaseRepository<Permission> {
     });
     return repositoryTransaction;
   }
-
-  deleteAll(data: Partial<Permission>): Promise<boolean> {
-    return this.queryBuilder.where(data).delete();
-  }
 }

--- a/src/server/repositories/relations.ts
+++ b/src/server/repositories/relations.ts
@@ -1,0 +1,15 @@
+import { Relation } from '../../config/types.js';
+import { AbstractRepositoryOptions, BaseRepository, BaseTransaction } from './base.js';
+
+export class RelationsRepository extends BaseRepository<Relation> {
+  constructor(collection: string = 'superfast_relations', options?: AbstractRepositoryOptions) {
+    super(collection, options);
+  }
+
+  transacting(trx: BaseTransaction): RelationsRepository {
+    const repositoryTransaction = new RelationsRepository(this.collection, {
+      knex: trx.transaction,
+    });
+    return repositoryTransaction;
+  }
+}

--- a/src/server/repositories/relations.ts
+++ b/src/server/repositories/relations.ts
@@ -12,10 +12,4 @@ export class RelationsRepository extends BaseRepository<Relation> {
     });
     return repositoryTransaction;
   }
-
-  nullifyOneRelation(collection: string, field: string): Promise<boolean> {
-    return this.queryBuilder
-      .where({ one_collection: collection, one_field: field })
-      .update({ one_field: null });
-  }
 }

--- a/src/server/repositories/relations.ts
+++ b/src/server/repositories/relations.ts
@@ -12,4 +12,10 @@ export class RelationsRepository extends BaseRepository<Relation> {
     });
     return repositoryTransaction;
   }
+
+  nullifyOneRelation(collection: string, field: string): Promise<boolean> {
+    return this.queryBuilder
+      .where({ one_collection: collection, one_field: field })
+      .update({ one_field: null });
+  }
 }

--- a/src/server/repositories/users.ts
+++ b/src/server/repositories/users.ts
@@ -16,7 +16,7 @@ export class UsersRepository extends BaseRepository<User> {
 
   async create(item: Omit<User, 'id'>): Promise<User> {
     await this.checkUniqueEmail(item.email);
-    const [output] = await this.queryBuilder.insert(item).returning('id');
+    const [output] = await this.queryBuilder.insert(item).returning('*');
 
     return output as Promise<User>;
   }

--- a/src/server/router/apiRouter.ts
+++ b/src/server/router/apiRouter.ts
@@ -8,6 +8,7 @@ import { contents } from '../controllers/contents.js';
 import { fields } from '../controllers/fields.js';
 import { files } from '../controllers/files.js';
 import { projectSettings } from '../controllers/projectSettings.js';
+import { relations } from '../controllers/relations.js';
 import { roles } from '../controllers/roles.js';
 import { users } from '../controllers/users.js';
 import { authHandler } from '../middleware/authHandler.js';
@@ -38,5 +39,6 @@ router.use(contents);
 router.use(projectSettings);
 router.use(authentications);
 router.use(files);
+router.use(relations);
 
 export const apiRouter = router;


### PR DESCRIPTION
## 何をしたか
- コンテンツタイプに OneToMany フィールドを追加
- relations APIの追加
- relations テーブルの one_field を not null に変更
  - 所有者側のエンティティのフィールド削除後に、フィールドを付け替えるユースケースを想定していたが、複雑化するため廃止
- リファクタ
  - フィールド作成のAPIエンドポイントを `/collections/:slug/fields` → `/fields` に変更