### PR TITLE
fix: レコード作成時の returning を削除する

### DIFF
--- a/src/admin/pages/ContentType/Context/index.tsx
+++ b/src/admin/pages/ContentType/Context/index.tsx
@@ -23,7 +23,7 @@ export const CollectionContextProvider: React.FC<{ children: React.ReactNode }> 
   const createCollection = useSWRMutation(
     '/collections',
     async (url: string, { arg }: { arg: Record<string, any> }) => {
-      return api.post<{ collection: Collection }>(url, arg).then((res) => res.data.collection);
+      return api.post<{ id: number }>(url, arg).then((res) => res.data.id);
     }
   );
 

--- a/src/admin/pages/ContentType/Context/types.ts
+++ b/src/admin/pages/ContentType/Context/types.ts
@@ -5,7 +5,7 @@ import { Collection, Field } from '../../../../config/types.js';
 export type CollectionContext = {
   getCollection: (id: string) => SWRMutationResponse<Collection>;
   getCollections: () => SWRResponse<Collection[]>;
-  createCollection: SWRMutationResponse<Collection, any, Record<string, any>, any>;
+  createCollection: SWRMutationResponse<number, any, Record<string, any>, any>;
   updateCollection: (id: string) => SWRMutationResponse<void, any, Record<string, any>, any>;
   getFields: (slug: string | null, config?: SWRConfiguration) => SWRResponse<Field[]>;
   updateFields: () => SWRMutationResponse<void, any, Record<string, any>, any>;

--- a/src/admin/pages/ContentType/Create/index.tsx
+++ b/src/admin/pages/ContentType/Create/index.tsx
@@ -42,9 +42,9 @@ const CreateContentTypePageImpl: React.FC = () => {
 
   const onSubmit: SubmitHandler<FormValues> = async (form: FormValues) => {
     try {
-      const collection = await trigger(form);
+      const collectionId = await trigger(form);
       enqueueSnackbar(t('toast.created_successfully'), { variant: 'success' });
-      navigate(`../content-types/${collection!.id}`);
+      navigate(`../content-types/${collectionId!}`);
     } catch (e) {
       logger.error(e);
     }

--- a/src/admin/pages/Role/Context/index.tsx
+++ b/src/admin/pages/Role/Context/index.tsx
@@ -18,7 +18,7 @@ export const RoleContextProvider: React.FC<{ children: React.ReactNode }> = ({ c
 
   const createRole = () =>
     useSWRMutation(`/roles`, async (url: string, { arg }: { arg: Record<string, any> }) => {
-      return api.post<{ role: Role }>(url, arg).then((res) => res.data.role);
+      return api.post<{ id: number }>(url, arg).then((res) => res.data.id);
     });
 
   const updateRole = (id: string) =>

--- a/src/admin/pages/Role/Context/types.ts
+++ b/src/admin/pages/Role/Context/types.ts
@@ -5,7 +5,7 @@ import { Collection, Permission, Role } from '../../../../config/types.js';
 export type RoleContext = {
   getRoles: () => SWRResponse<Role[]>;
   getRole: (id: string) => SWRMutationResponse<Role>;
-  createRole: () => SWRMutationResponse<Role, any, Record<string, any>, any>;
+  createRole: () => SWRMutationResponse<number, any, Record<string, any>, any>;
   updateRole: (id: string) => SWRMutationResponse<void, any, Record<string, any>, any>;
   getCollections: (config?: SWRConfiguration) => SWRResponse<Collection[]>;
   getPermissions: (id: string, config?: SWRConfiguration) => SWRResponse<Permission[]>;

--- a/src/admin/pages/Role/Create/index.tsx
+++ b/src/admin/pages/Role/Create/index.tsx
@@ -28,7 +28,7 @@ const CreateRolePageImpl: React.FC = () => {
   const navigate = useNavigate();
   const { enqueueSnackbar } = useSnackbar();
   const { createRole } = useRole();
-  const { data, trigger, isMutating } = createRole();
+  const { data: roleId, trigger, isMutating } = createRole();
   const {
     control,
     handleSubmit,
@@ -43,10 +43,10 @@ const CreateRolePageImpl: React.FC = () => {
   });
 
   useEffect(() => {
-    if (data === undefined) return;
+    if (roleId === undefined) return;
     enqueueSnackbar(t('toast.created_successfully'), { variant: 'success' });
-    navigate(`../roles/${data.id}`);
-  }, [data]);
+    navigate(`../roles/${roleId}`);
+  }, [roleId]);
 
   const onSubmit: SubmitHandler<FormValues> = (form: FormValues) => {
     trigger(form);

--- a/src/admin/pages/User/Context/index.tsx
+++ b/src/admin/pages/User/Context/index.tsx
@@ -18,7 +18,7 @@ export const UserContextProvider: React.FC<{ children: React.ReactNode }> = ({ c
 
   const createUser = () =>
     useSWRMutation(`/users`, async (url: string, { arg }: { arg: Record<string, any> }) => {
-      return api.post<{ user: User }>(url, arg).then((res) => res.data.user);
+      return api.post<{ id: number }>(url, arg).then((res) => res.data.id);
     });
 
   const updateUser = (id: string) =>

--- a/src/admin/pages/User/Context/types.ts
+++ b/src/admin/pages/User/Context/types.ts
@@ -6,6 +6,6 @@ export type UserContext = {
   getUsers: () => SWRResponse<User[]>;
   getUser: (id: string) => SWRMutationResponse<User>;
   getRoles: (config?: SWRConfiguration) => SWRResponse<Role[]>;
-  createUser: () => SWRMutationResponse<User, any, Record<string, any>, any>;
+  createUser: () => SWRMutationResponse<number, any, Record<string, any>, any>;
   updateUser: (id: string) => SWRMutationResponse<void, any, Record<string, any>, any>;
 };

--- a/src/admin/pages/collections/Context/index.tsx
+++ b/src/admin/pages/collections/Context/index.tsx
@@ -47,7 +47,7 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
     useSWRMutation(
       `/collections/${slug}/contents`,
       async (url: string, { arg }: { arg: Record<string, any> }) => {
-        return api.post<{ content: unknown }>(url, arg).then((res) => res.data.content);
+        return api.post<{ id: number }>(url, arg).then((res) => res.data.id);
       }
     );
 

--- a/src/admin/pages/collections/Context/types.ts
+++ b/src/admin/pages/collections/Context/types.ts
@@ -12,7 +12,7 @@ export type ContentContext = {
   getContent: (slug: string, id: string | null) => SWRMutationResponse<any>;
   getFields: (slug: string, config?: SWRConfiguration) => SWRResponse<Field[]>;
   getPreviewContents: (slug: string) => SWRMutationResponse<any[]>;
-  createContent: (slug: string) => SWRMutationResponse<unknown, any, Record<string, any>, any>;
+  createContent: (slug: string) => SWRMutationResponse<number, any, Record<string, any>, any>;
   updateContent: (
     slug: string,
     id: string

--- a/src/server/controllers/collections.ts
+++ b/src/server/controllers/collections.ts
@@ -59,7 +59,7 @@ router.post(
     delete data.status;
 
     await repository.transaction(async (tx) => {
-      const collection = await repository.transacting(tx).create(data);
+      const collectionId = await repository.transacting(tx).create(data);
 
       await tx.transaction.schema.createTable(req.body.collection, (table) => {
         table.increments();
@@ -103,7 +103,7 @@ router.post(
       ];
       await fieldsRepository.transacting(tx).createMany(fields);
 
-      res.json({ collection });
+      res.json({ id: collectionId });
     });
   })
 );

--- a/src/server/controllers/contents.ts
+++ b/src/server/controllers/contents.ts
@@ -46,10 +46,10 @@ router.post(
     const slug = req.params.slug;
     const repository = new ContentsRepository(slug);
 
-    const content = await repository.create(req.body);
+    const contentId = await repository.create(req.body);
 
     res.json({
-      content,
+      id: contentId,
     });
   })
 );

--- a/src/server/controllers/fields.ts
+++ b/src/server/controllers/fields.ts
@@ -44,8 +44,8 @@ router.post(
     const collections = await collectionsRepository.read({ collection: slug });
 
     await repository.transaction(async (tx) => {
-      const result = await repository.transacting(tx).create(req.body);
-      const field = await repository.transacting(tx).readOne(result.id);
+      const fieldId = await repository.transacting(tx).create(req.body);
+      const field = await repository.transacting(tx).readOne(fieldId);
       await tx.transaction.schema.alterTable(collections[0].collection, (table) => {
         addColumnToTable(field, table);
       });

--- a/src/server/controllers/roles.ts
+++ b/src/server/controllers/roles.ts
@@ -41,10 +41,10 @@ router.post(
   asyncHandler(async (req: Request, res: Response) => {
     const repository = new RolesRepository();
 
-    const role = await repository.create(req.body);
+    const roleId = await repository.create(req.body);
 
     res.json({
-      role,
+      id: roleId,
     });
   })
 );
@@ -117,10 +117,10 @@ router.post(
       role_id: id,
     };
 
-    const permission = await permissionsRepository.create(data);
+    const permissionId = await permissionsRepository.create(data);
 
     res.json({
-      permission,
+      id: permissionId,
     });
   })
 );

--- a/src/server/controllers/users.ts
+++ b/src/server/controllers/users.ts
@@ -53,10 +53,10 @@ router.post(
     const repository = new UsersRepository();
 
     req.body.password = await oneWayHash(req.body.password);
-    const user = await repository.create(req.body);
+    const userId = await repository.create(req.body);
 
     res.json({
-      user,
+      id: userId,
     });
   })
 );

--- a/src/server/repositories/base.ts
+++ b/src/server/repositories/base.ts
@@ -8,7 +8,7 @@ export type AbstractRepositoryOptions = {
 type AbstractRepository<T> = {
   read(data: Partial<T>): Promise<T[]>;
   readOne(id: number | Partial<T>): Promise<T>;
-  create(item: Omit<T, 'id'>): Promise<T>;
+  create(item: Omit<T, 'id'>): Promise<number>;
   createMany(items: T[]): Promise<T[]>;
   update(id: number, item: Partial<T>): Promise<boolean>;
   delete(id: number): Promise<boolean>;
@@ -48,10 +48,9 @@ export abstract class BaseRepository<T> implements AbstractRepository<T> {
     return this.queryBuilder.where('id', id).first();
   }
 
-  async create(item: Omit<T, 'id'>): Promise<T> {
-    const [output] = await this.queryBuilder.insert(item).returning('id');
-
-    return output as Promise<T>;
+  async create(item: Omit<T, 'id'>): Promise<number> {
+    const [output] = await this.queryBuilder.insert(item);
+    return output;
   }
 
   createMany(items: T[]): Promise<T[]> {

--- a/src/server/repositories/collections.ts
+++ b/src/server/repositories/collections.ts
@@ -14,11 +14,10 @@ export class CollectionsRepository extends BaseRepository<Collection> {
     return repositoryTransaction;
   }
 
-  async create(item: Omit<Collection, 'id'>): Promise<Collection> {
+  async create(item: Omit<Collection, 'id'>): Promise<number> {
     await this.checkUniqueCollection(item.collection);
-    const [output] = await this.queryBuilder.insert(item).returning('id');
-
-    return output as Promise<Collection>;
+    const [output] = await this.queryBuilder.insert(item);
+    return output;
   }
 
   private async checkUniqueCollection(collection: string) {

--- a/src/server/repositories/fields.ts
+++ b/src/server/repositories/fields.ts
@@ -22,11 +22,10 @@ export class FieldsRepository extends BaseRepository<Field> {
     return this.queryBuilder.where(data).delete();
   }
 
-  async create(item: Omit<Field, 'id'>): Promise<Field> {
+  async create(item: Omit<Field, 'id'>): Promise<number> {
     await this.checkUniqueField(item.collection, item.field);
-    const [output] = await this.queryBuilder.insert(item).returning('id');
-
-    return output as Promise<Field>;
+    const [output] = await this.queryBuilder.insert(item);
+    return output;
   }
 
   private async checkUniqueField(collection: string, field: string) {

--- a/src/server/repositories/users.ts
+++ b/src/server/repositories/users.ts
@@ -14,11 +14,10 @@ export class UsersRepository extends BaseRepository<User> {
     return repositoryTransaction;
   }
 
-  async create(item: Omit<User, 'id'>): Promise<User> {
+  async create(item: Omit<User, 'id'>): Promise<number> {
     await this.checkUniqueEmail(item.email);
-    const [output] = await this.queryBuilder.insert(item).returning('id');
-
-    return output as Promise<User>;
+    const [output] = await this.queryBuilder.insert(item);
+    return output;
   }
 
   async update(id: number, item: Partial<User>): Promise<boolean> {

--- a/src/server/services/file.ts
+++ b/src/server/services/file.ts
@@ -9,8 +9,7 @@ export class FileService {
     await storage.put(file.fileNameDisk, buffer);
 
     const repository = new FilesRepository();
-    const result = await repository.create(file);
-
-    return result.id;
+    const fileId = await repository.create(file);
+    return fileId;
   }
 }


### PR DESCRIPTION
## 背景
postデータが空の場合に、レコード数のみが返ってくる（SQLiteのみで確認）

## 原因
以下の issue に関連している。returning を設定した上で、 SQLite で insert するとレコード数のみが返ってくる。
https://github.com/knex/knex/issues/5126

なお、post データによって返却される値が異なる。

### post データが複数の場合 / returning('id')
```
{ id: 5 }
```

### post データが空の場合 / returning('id')
```
5
```

## 何をしたか
- レコード作成時の returning を削除する