### PR TITLE
コンテンツ登録フォームに OneToMany フィールドを追加する 

### DIFF
--- a/src/admin/components/elements/Table/CheckBoxTable/index.tsx
+++ b/src/admin/components/elements/Table/CheckBoxTable/index.tsx
@@ -1,0 +1,73 @@
+import {
+  Checkbox,
+  Table as MuiTable,
+  Paper,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Cell } from '../Cell/index.js';
+import { Props } from './types.js';
+
+export const CheckBoxTable: React.FC<Props> = ({ columns, rows, onChange }) => {
+  const { t } = useTranslation();
+  const onCheck = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const row = rows.filter((row) => row.id.toString() === e.target.value);
+    const checked = e.target.checked;
+    onChange(row[0], checked);
+  };
+
+  return rows.length > 0 ? (
+    <TableContainer component={Paper}>
+      <MuiTable aria-label="simple table">
+        <TableHead>
+          <TableRow>
+            <TableCell />
+            {columns.map((column) => (
+              <TableCell key={`column-${column.field.field}`}>{column.label}</TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow
+              key={`row-${row.id}`}
+              sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+            >
+              <TableCell padding="checkbox">
+                <Checkbox
+                  color="primary"
+                  onChange={onCheck}
+                  value={row.id}
+                  inputProps={{
+                    'aria-labelledby': `table-checkbox-${row.id}`,
+                  }}
+                />
+              </TableCell>
+              {columns.map((col, i) => (
+                <TableCell key={`cell-${col.field.field}`} component="th" scope="row">
+                  {col.customRenderCell ? (
+                    col.customRenderCell(i, row, row[col.field.field])
+                  ) : (
+                    <Cell
+                      colIndex={i}
+                      type={col.field.type}
+                      rowData={row}
+                      cellData={row[col.field.field]}
+                    />
+                  )}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </MuiTable>
+    </TableContainer>
+  ) : (
+    <span>{t('no_contents')}</span>
+  );
+};

--- a/src/admin/components/elements/Table/CheckBoxTable/types.ts
+++ b/src/admin/components/elements/Table/CheckBoxTable/types.ts
@@ -1,0 +1,12 @@
+import { Column } from '../types.js';
+
+type Row = {
+  id: number;
+  [path: string]: unknown;
+};
+
+export type Props = {
+  columns: Column[];
+  rows: Row[];
+  onChange: (row: Row, checked: boolean) => void;
+};

--- a/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/index.tsx
+++ b/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/index.tsx
@@ -1,0 +1,120 @@
+import { CloseOutlined } from '@mui/icons-material';
+import { Box, Button, Drawer, IconButton, Stack, Typography } from '@mui/material';
+import { t } from 'i18next';
+import React, { useEffect, useState } from 'react';
+import { referencedTypes } from '../../../../../../server/database/schemas.js';
+import {
+  ContentContextProvider,
+  useContent,
+} from '../../../../../pages/collections/Context/index.js';
+import { buildColumnFields } from '../../../../../pages/collections/List/buildColumnFields.js';
+import { buildColumns } from '../../../../../utilities/buildColumns.js';
+import { Cell } from '../../../../elements/Table/Cell/index.js';
+import { CheckBoxTable } from '../../../../elements/Table/CheckBoxTable/index.js';
+import { Column } from '../../../../elements/Table/types.js';
+import { ComposeWrapper } from '../../../../utilities/ComposeWrapper/index.js';
+import { theme } from '../../../../utilities/Theme/Default/index.js';
+import { Props } from './types.js';
+
+const AddExistContentsImpl: React.FC<Props> = ({
+  collection,
+  field,
+  openState,
+  onSuccess,
+  onClose,
+}) => {
+  const [columns, setColumns] = useState<Column[]>([]);
+  const [selectedContentIds, setSelectedContentIds] = useState<number[]>([]);
+
+  const { getRelations, getContents, getFields } = useContent();
+  const { data: relations } = getRelations(collection, field);
+  const relationFetched = (relations && relations[0] !== null) || false;
+  const { data: contents } = getContents(
+    relationFetched,
+    relations ? relations[0].many_collection : ''
+  );
+  const { data: fields } = getFields(
+    relations ? relations[0].many_collection : '',
+    relationFetched
+  );
+
+  useEffect(() => {
+    if (fields === undefined) return;
+    // excludes referenced fields.
+    const filtered = fields.filter((field) => !referencedTypes.includes(field.interface));
+    const columnFields = buildColumnFields(filtered);
+    const columns = buildColumns(columnFields, (i: number, row: any, data: any) => (
+      <Cell colIndex={i} type={columnFields[i].type} rowData={row} cellData={data} />
+    ));
+    setColumns(columns);
+  }, [fields]);
+
+  const handleCheck = (row: any, checked: boolean) => {
+    if (checked) {
+      setSelectedContentIds([...selectedContentIds, row.id]);
+    } else {
+      const filtered = selectedContentIds.filter((contentId) => contentId !== row.id);
+      setSelectedContentIds(filtered);
+    }
+  };
+
+  const onToggle = () => (event: React.KeyboardEvent | React.MouseEvent) => {
+    if (
+      event.type === 'keydown' &&
+      ((event as React.KeyboardEvent).key === 'Tab' ||
+        (event as React.KeyboardEvent).key === 'Shift')
+    ) {
+      return;
+    }
+
+    onClose();
+  };
+
+  const onSelected = () => {
+    const selectedContents = contents?.filter((content) => selectedContentIds.includes(content.id));
+    onSuccess(selectedContents || []);
+    setSelectedContentIds([]);
+  };
+
+  return (
+    <Stack>
+      <Drawer
+        anchor="right"
+        open={openState}
+        onClose={onToggle()}
+        sx={{ zIndex: theme.zIndex.appBar + 200 }}
+      >
+        <Box sx={{ width: 660 }}>
+          <Stack direction="row" columnGap={2} sx={{ p: 1 }}>
+            <IconButton aria-label="close" onClick={onClose}>
+              <CloseOutlined />
+            </IconButton>
+            <Box display="flex" alignItems="center">
+              <Typography variant="h6">{t('select_contents')}</Typography>
+            </Box>
+          </Stack>
+          <Stack rowGap={3} sx={{ p: 2 }}>
+            {contents !== undefined && (
+              <CheckBoxTable columns={columns} rows={contents} onChange={handleCheck} />
+            )}
+          </Stack>
+          <Stack sx={{ p: 2 }}>
+            <Button
+              variant="contained"
+              onClick={onSelected}
+              disabled={selectedContentIds.length === 0}
+              size="large"
+              fullWidth
+            >
+              {t('save')}
+            </Button>
+          </Stack>
+        </Box>
+      </Drawer>
+    </Stack>
+  );
+};
+
+export const AddExistContents = ComposeWrapper({ context: ContentContextProvider })(
+  AddExistContentsImpl
+);

--- a/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/types.ts
+++ b/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/types.ts
@@ -1,0 +1,7 @@
+export type Props = {
+  collection: string;
+  field: string;
+  openState: boolean;
+  onSuccess: (contents: Partial<{ id: number }>[]) => void;
+  onClose: () => void;
+};

--- a/src/admin/components/forms/fieldTypes/ListOneToMany/index.tsx
+++ b/src/admin/components/forms/fieldTypes/ListOneToMany/index.tsx
@@ -1,10 +1,51 @@
-import React from 'react';
+import { Box, Button } from '@mui/material';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ContentContextProvider } from '../../../../pages/collections/Context/index.js';
 import { ComposeWrapper } from '../../../utilities/ComposeWrapper/index.js';
 import { Props } from '../types.js';
+import { AddExistContents } from './AddExistContents/index.js';
 
-export const ListOneToManyTypeImpl: React.FC<Props> = ({}) => {
-  return <></>;
+export const ListOneToManyTypeImpl: React.FC<Props> = ({
+  form: { register, setValue, watch },
+  field: meta,
+}) => {
+  const [addRelationsOpen, setAddRelationsOpen] = useState(false);
+
+  const { t } = useTranslation();
+  const required = meta.required && { required: t('yup.mixed.required') };
+
+  const onToggleAddRelations = (state: boolean) => {
+    setAddRelationsOpen(state);
+  };
+
+  const handleSelectedContents = (contents: Partial<{ id: number }>[]) => {
+    setAddRelationsOpen(false);
+    setValue(meta.field, contents);
+  };
+
+  return (
+    <>
+      <AddExistContents
+        collection={meta.collection}
+        field={meta.field}
+        openState={addRelationsOpen}
+        onSuccess={(contents) => handleSelectedContents(contents)}
+        onClose={() => onToggleAddRelations(false)}
+      />
+      {watch(meta.field) &&
+        watch(meta.field).map((data: any) => <Box key={data.id}>{data.id}</Box>)}
+      <Button
+        variant="contained"
+        onClick={() => onToggleAddRelations(true)}
+        size="large"
+        sx={{ mt: 2 }}
+      >
+        {t('add')}
+      </Button>
+      <input hidden {...register(meta.field, { ...required })} />
+    </>
+  );
 };
 
 export const ListOneToManyType = ComposeWrapper({ context: ContentContextProvider })(

--- a/src/admin/components/utilities/ComposeWrapper/index.tsx
+++ b/src/admin/components/utilities/ComposeWrapper/index.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef } from 'react';
+import { pick } from '../../../../utilities/pick.js';
 
 type ComposedWrappers<CW> = {
   [key in keyof CW]: React.FC<CW[key]>;
@@ -11,14 +12,6 @@ type ComposedWrapperProps<T extends {}, CW> = T & {
 function omit(obj: any, ...keys: string[][]) {
   const keysToRemove = new Set(keys.flat());
   return Object.fromEntries(Object.entries(obj).filter(([k]) => !keysToRemove.has(k)));
-}
-
-function pick(obj: any, ...keys: string[][]) {
-  const ret: Record<string, any> = {};
-  keys.flat().forEach((key) => {
-    if (obj[key]) ret[key] = obj[key];
-  });
-  return ret;
 }
 
 export const ComposeWrapper = <CW,>(wrappers: ComposedWrappers<CW>) => {

--- a/src/admin/pages/User/index.tsx
+++ b/src/admin/pages/User/index.tsx
@@ -19,8 +19,6 @@ const UserPageImpl: React.FC = () => {
   const { getUsers } = useUser();
   const { data } = getUsers();
 
-  console.log(data);
-
   const fields = [
     { field: 'user_name', label: t('user_name'), type: Type.Text },
     { field: 'name', label: t('name'), type: Type.Text },

--- a/src/admin/pages/collections/Context/index.tsx
+++ b/src/admin/pages/collections/Context/index.tsx
@@ -35,9 +35,13 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
       api.get<{ content: unknown }>(url).then((res) => res.data.content)
     );
 
-  const getFields = (collection: string, config?: SWRConfiguration): SWRResponse =>
+  const getFields = (
+    collection: string,
+    canFetch: boolean = true,
+    config?: SWRConfiguration
+  ): SWRResponse =>
     useSWR(
-      `/collections/${collection}/fields`,
+      canFetch ? `/collections/${collection}/fields` : null,
       (url) => api.get<{ fields: Field[] }>(url).then((res) => res.data.fields),
       config
     );

--- a/src/admin/pages/collections/Context/index.tsx
+++ b/src/admin/pages/collections/Context/index.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useMemo } from 'react';
 import useSWR, { SWRConfiguration, SWRResponse } from 'swr';
 import useSWRMutation, { SWRMutationResponse } from 'swr/mutation';
-import { Field, File } from '../../../../config/types.js';
+import { Field, File, Relation } from '../../../../config/types.js';
 import { api } from '../../../utilities/api.js';
 import { ContentContext } from './types.js';
 
@@ -73,6 +73,11 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
       return api.post<{ file: File; raw: string }>(url, arg).then((res) => res.data);
     });
 
+  const getRelations = (collection: string, field: string): SWRResponse =>
+    useSWR(`/relations/${collection}/${field}`, (url) =>
+      api.get<{ relations: Relation[] }>(url).then((res) => res.data.relations)
+    );
+
   const value = useMemo(
     () => ({
       getContents,
@@ -84,6 +89,7 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
       updateContent,
       getFileImage,
       createFileImage,
+      getRelations,
     }),
     [
       getContents,
@@ -95,6 +101,7 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
       updateContent,
       getFileImage,
       createFileImage,
+      getRelations,
     ]
   );
 

--- a/src/admin/pages/collections/Context/types.ts
+++ b/src/admin/pages/collections/Context/types.ts
@@ -14,7 +14,11 @@ export type ContentContext = {
     config?: SWRConfiguration
   ) => SWRResponse<any>;
   getContent: (collection: string, id: string | null) => SWRMutationResponse<any>;
-  getFields: (collection: string, config?: SWRConfiguration) => SWRResponse<Field[]>;
+  getFields: (
+    collection: string,
+    canFetch?: boolean,
+    config?: SWRConfiguration
+  ) => SWRResponse<Field[]>;
   getPreviewContents: (collection: string) => SWRMutationResponse<any[]>;
   createContent: (collection: string) => SWRMutationResponse<number, any, Record<string, any>, any>;
   updateContent: (

--- a/src/admin/pages/collections/Context/types.ts
+++ b/src/admin/pages/collections/Context/types.ts
@@ -1,6 +1,6 @@
 import { SWRConfiguration, SWRResponse } from 'swr';
 import { SWRMutationResponse } from 'swr/mutation';
-import { Field, File } from '../../../../config/types.js';
+import { Field, File, Relation } from '../../../../config/types.js';
 
 export type ContentContext = {
   getContents: (
@@ -28,4 +28,5 @@ export type ContentContext = {
     Record<string, any>,
     any
   >;
+  getRelations: (collection: string, field: string) => SWRResponse<Relation[]>;
 };

--- a/src/admin/pages/collections/Edit/index.tsx
+++ b/src/admin/pages/collections/Edit/index.tsx
@@ -22,7 +22,7 @@ const EditCollectionPageImpl: React.FC<Props> = ({ collection }) => {
   const { hasPermission } = useAuth();
   const navigate = useNavigate();
   const { getContent, getFields, createContent, updateContent } = useContent();
-  const { data: metaFields } = getFields(collection.collection, { suspense: true });
+  const { data: metaFields } = getFields(collection.collection, true, { suspense: true });
   const { data: content, trigger: getContentTrigger } = getContent(
     collection.collection,
     id || null

--- a/src/lang/translations/en/translation.json
+++ b/src/lang/translations/en/translation.json
@@ -92,6 +92,7 @@
   "disabled": "Disabled",
   "related_content": "Related Content Type",
   "foreign_key": "Foreign Key",
+  "select_contents": "Select Contents",
   "dialog": {
     "confirm_deletion_title": "Confirm deletion.",
     "confirm_deletion": "Once deleted, it cannot be restored. Are you sure you want to delete it?",

--- a/src/lang/translations/ja/translation.json
+++ b/src/lang/translations/ja/translation.json
@@ -92,6 +92,7 @@
   "disabled": "無効",
   "related_content": "関連コンテンツ",
   "foreign_key": "外部キー",
+  "select_contents": "コンテンツを選択",
   "dialog": {
     "confirm_deletion_title": "削除の確認",
     "confirm_deletion": "一度削除すると復元できません。削除してよろしいですか？",

--- a/src/server/controllers/relations.ts
+++ b/src/server/controllers/relations.ts
@@ -1,6 +1,9 @@
 import express, { Request, Response } from 'express';
 import { asyncHandler } from '../middleware/asyncHandler.js';
-import { permissionsHandler } from '../middleware/permissionsHandler.js';
+import {
+  collectionPermissionsHandler,
+  permissionsHandler,
+} from '../middleware/permissionsHandler.js';
 import { RelationsRepository } from '../repositories/relations.js';
 
 const router = express.Router();
@@ -26,6 +29,22 @@ router.post(
       res.json({
         relation,
       });
+    });
+  })
+);
+
+router.get(
+  '/relations/:collection/:field',
+  collectionPermissionsHandler('read'),
+  asyncHandler(async (req: Request, res: Response) => {
+    const collection = req.params.collection;
+    const field = req.params.field;
+    const repository = new RelationsRepository();
+
+    const relations = await repository.readRelations(collection, field);
+
+    res.json({
+      relations,
     });
   })
 );

--- a/src/server/database/schemas.ts
+++ b/src/server/database/schemas.ts
@@ -71,3 +71,5 @@ export type Relation = {
   one_collection: string;
   one_field: string;
 } & PrimaryKey;
+
+export const referencedTypes = ['listOneToMany'];

--- a/src/server/repositories/contents.ts
+++ b/src/server/repositories/contents.ts
@@ -1,6 +1,6 @@
 import { BaseRepository, BaseTransaction } from './base.js';
 
-export class ContentsRepository extends BaseRepository<unknown> {
+export class ContentsRepository extends BaseRepository<any> {
   transacting(trx: BaseTransaction): ContentsRepository {
     const repositoryTransaction = new ContentsRepository(this.collection, {
       knex: trx.transaction,

--- a/src/server/repositories/relations.ts
+++ b/src/server/repositories/relations.ts
@@ -12,4 +12,10 @@ export class RelationsRepository extends BaseRepository<Relation> {
     });
     return repositoryTransaction;
   }
+
+  readRelations(collection: string, field: string): Promise<Relation[]> {
+    return this.queryBuilder
+      .where({ one_collection: collection, one_field: field })
+      .orWhere({ many_collection: collection, many_field: field });
+  }
 }

--- a/src/utilities/pick.ts
+++ b/src/utilities/pick.ts
@@ -1,0 +1,10 @@
+// This function returns a new object with only the specified keys picked from the original object.
+// Alternatives to lodash _.pick.
+// ref: https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_pick
+export function pick(obj: any, ...keys: string[][]) {
+  const ret: Record<string, any> = {};
+  keys.flat().forEach((key) => {
+    if (obj[key]) ret[key] = obj[key];
+  });
+  return ret;
+}


### PR DESCRIPTION
## 何をしたか
- コンテンツ登録フォームに OneToMany フィールドを追加した
- CheckBoxTable コンポーネントの作成
- リファクタ
  - pick(lodash _.pick の代替え品) のユーティリティ化
  - getFields に条件付きフェッチプロパティを追加
  - ContentsRepository で扱うタイプを unknown から any に変更
    - contents はタイプ解決できず結局 any にして使うしかないため

## やらなかったこと
- コンテンツ一覧表示で、many フィールドのIDを表示していない
  - 愚直に取ると N+1 によるパフォーマンス影響があるため別チケットで対応