### PR TITLE
refactor: canFetch を第2引数に変更して、指定なしの場合はデフォルト true とする

### DIFF
--- a/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/index.tsx
+++ b/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/index.tsx
@@ -30,8 +30,8 @@ const AddExistContentsImpl: React.FC<Props> = ({
   const { data: relations } = getRelations(collection, field);
   const relationFetched = (relations && relations[0] !== null) || false;
   const { data: contents } = getContents(
-    relationFetched,
-    relations ? relations[0].many_collection : ''
+    relations ? relations[0].many_collection : '',
+    relationFetched
   );
   const { data: fields } = getFields(
     relations ? relations[0].many_collection : '',

--- a/src/admin/components/forms/fieldTypes/SelectDropdownManyToOne/AddExistContents/index.tsx
+++ b/src/admin/components/forms/fieldTypes/SelectDropdownManyToOne/AddExistContents/index.tsx
@@ -30,8 +30,8 @@ const AddExistContentsImpl: React.FC<Props> = ({
   const { data: relations } = getRelations(collection, field);
   const relationFetched = (relations && relations[0] !== null) || false;
   const { data: contents } = getContents(
-    relationFetched,
-    relations ? relations[0].one_collection : ''
+    relations ? relations[0].one_collection : '',
+    relationFetched
   );
   const { data: fields } = getFields(relations ? relations[0].one_collection : '', relationFetched);
 

--- a/src/admin/pages/collections/Context/index.tsx
+++ b/src/admin/pages/collections/Context/index.tsx
@@ -9,8 +9,8 @@ const Context = createContext({} as ContentContext);
 
 export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const getContents = (
-    canFetch: boolean,
     collection: string,
+    canFetch: boolean = true,
     config?: SWRConfiguration
   ): SWRResponse =>
     useSWR(
@@ -20,8 +20,8 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
     );
 
   const getSingletonContent = (
-    canFetch: boolean,
     collection: string,
+    canFetch: boolean = true,
     config?: SWRConfiguration
   ): SWRResponse =>
     useSWR(

--- a/src/admin/pages/collections/Context/types.ts
+++ b/src/admin/pages/collections/Context/types.ts
@@ -4,13 +4,13 @@ import { Field, File, Relation } from '../../../../config/types.js';
 
 export type ContentContext = {
   getContents: (
-    canFetch: boolean,
     collection: string,
+    canFetch?: boolean,
     config?: SWRConfiguration
   ) => SWRResponse<any[]>;
   getSingletonContent: (
-    canFetch: boolean,
     collection: string,
+    canFetch?: boolean,
     config?: SWRConfiguration
   ) => SWRResponse<any>;
   getContent: (collection: string, id: string | null) => SWRMutationResponse<any>;

--- a/src/admin/pages/collections/List/Default.tsx
+++ b/src/admin/pages/collections/List/Default.tsx
@@ -22,7 +22,7 @@ const DefaultListPageImpl: React.FC<Props> = ({ collection }) => {
   const { getContents, getFields } = useContent();
   const { data: metaFields } = getFields(collection.collection);
   const fieldFetched = metaFields !== undefined;
-  const { data: contents } = getContents(fieldFetched, collection.collection);
+  const { data: contents } = getContents(collection.collection, fieldFetched);
 
   useEffect(() => {
     if (metaFields === undefined) return;

--- a/src/admin/pages/collections/List/Singleton.tsx
+++ b/src/admin/pages/collections/List/Singleton.tsx
@@ -19,7 +19,7 @@ const SingletonPageImpl: React.FC<Props> = ({ collection }) => {
   const { getSingletonContent, getFields, createContent, updateContent } = useContent();
   const { data: metaFields } = getFields(collection.collection);
   const fieldFetched = metaFields !== undefined;
-  const { data: content } = getSingletonContent(fieldFetched, collection.collection);
+  const { data: content } = getSingletonContent(collection.collection, fieldFetched);
 
   const { trigger: createTrigger, isMutating: isCreateMutating } = createContent(
     collection.collection


### PR DESCRIPTION
## 何をしたか
- canFetch を第2引数に変更して、指定なしの場合はデフォルト true とする
  - 今後パラメータが増える場合に option としてまとめるため
  - getFields と統一した