### PR TITLE
refactor: テーブルセルで自動生成するリンクを削除して、customRenderCellで個別に実装可能にする

### DIFF
--- a/src/admin/components/elements/Table/Cell/index.tsx
+++ b/src/admin/components/elements/Table/Cell/index.tsx
@@ -3,26 +3,14 @@ import utc from 'dayjs/plugin/utc.js';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { castToBoolean } from '../../../../utilities/castToBoolean.js';
-import { RouterLink } from '../../Link/index.js';
 import { Props, Type } from './types.js';
 
 export const Cell: React.FC<Props> = (props) => {
-  const { colIndex, type, rowData, cellData } = props;
+  const { colIndex, type, cellData } = props;
   const { t } = useTranslation();
   dayjs.extend(utc);
 
-  let WrapElement: React.ComponentType<any> | string = 'span';
-
-  const wrapElementProps: {
-    to?: string;
-  } = {};
-
-  if (colIndex === 0) {
-    WrapElement = RouterLink;
-    wrapElementProps.to = `${rowData.id}`;
-  }
-
-  const sanitizedCellData = () => {
+  const sanitizedCellData: any = () => {
     if (colIndex === 0 && (cellData === null || String(cellData).trim() === '')) {
       return 'No data';
     }
@@ -44,5 +32,5 @@ export const Cell: React.FC<Props> = (props) => {
     }
   };
 
-  return <WrapElement {...wrapElementProps}>{sanitizedCellData()}</WrapElement>;
+  return <span>{sanitizedCellData()}</span>;
 };

--- a/src/admin/components/elements/Table/Cell/types.ts
+++ b/src/admin/components/elements/Table/Cell/types.ts
@@ -10,8 +10,5 @@ export const Type = {
 export type Props = {
   colIndex: number;
   type: (typeof Type)[keyof typeof Type];
-  rowData: {
-    [path: string]: unknown;
-  };
   cellData: unknown;
 };

--- a/src/admin/components/elements/Table/index.tsx
+++ b/src/admin/components/elements/Table/index.tsx
@@ -40,12 +40,7 @@ export const Table: React.FC<Props> = ({ columns, rows }) => {
                   {col.customRenderCell ? (
                     col.customRenderCell(i, row, row[col.field.field])
                   ) : (
-                    <Cell
-                      colIndex={i}
-                      type={col.field.type}
-                      rowData={row}
-                      cellData={row[col.field.field]}
-                    />
+                    <Cell colIndex={i} type={col.field.type} cellData={row[col.field.field]} />
                   )}
                 </TableCell>
               ))}

--- a/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/index.tsx
+++ b/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/index.tsx
@@ -43,9 +43,7 @@ const AddExistContentsImpl: React.FC<Props> = ({
     // excludes referenced fields.
     const filtered = fields.filter((field) => !referencedTypes.includes(field.interface));
     const columnFields = buildColumnFields(filtered);
-    const columns = buildColumns(columnFields, (i: number, row: any, data: any) => (
-      <Cell colIndex={i} type={columnFields[i].type} rowData={row} cellData={data} />
-    ));
+    const columns = buildColumns(columnFields);
     setColumns(columns);
   }, [fields]);
 

--- a/src/admin/components/forms/fieldTypes/SelectDropdownManyToOne/AddExistContents/index.tsx
+++ b/src/admin/components/forms/fieldTypes/SelectDropdownManyToOne/AddExistContents/index.tsx
@@ -40,9 +40,7 @@ const AddExistContentsImpl: React.FC<Props> = ({
     // excludes referenced fields.
     const filtered = fields.filter((field) => !referencedTypes.includes(field.interface));
     const columnFields = buildColumnFields(filtered);
-    const columns = buildColumns(columnFields, (i: number, row: any, data: any) => (
-      <Cell colIndex={i} type={columnFields[i].type} rowData={row} cellData={data} />
-    ));
+    const columns = buildColumns(columnFields);
     setColumns(columns);
   }, [fields]);
 

--- a/src/admin/pages/ContentType/index.tsx
+++ b/src/admin/pages/ContentType/index.tsx
@@ -3,7 +3,9 @@ import { Button, Stack } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2/Grid2.js';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { Collection } from '../../../config/types.js';
 import { RouterLink } from '../../components/elements/Link/index.js';
+import { Cell } from '../../components/elements/Table/Cell/index.js';
 import { Type } from '../../components/elements/Table/Cell/types.js';
 import { Table } from '../../components/elements/Table/index.js';
 import { ComposeWrapper } from '../../components/utilities/ComposeWrapper/index.js';
@@ -19,7 +21,10 @@ const ContentTypePageImpl: React.FC = () => {
 
   const fields = [{ field: 'collection', label: t('name'), type: Type.Text }];
 
-  const columns = buildColumns(fields);
+  const columns = buildColumns(fields, (i: number, row: Collection, data: any) => {
+    const cell = <Cell colIndex={i} type={fields[i].type} cellData={data} />;
+    return i === 0 ? <RouterLink to={`${row.id}`}>{cell}</RouterLink> : cell;
+  });
 
   return (
     <Stack rowGap={3}>

--- a/src/admin/pages/Role/index.tsx
+++ b/src/admin/pages/Role/index.tsx
@@ -3,7 +3,9 @@ import { Button, Stack } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2/Grid2.js';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { Role } from '../../../config/types.js';
 import { RouterLink } from '../../components/elements/Link/index.js';
+import { Cell } from '../../components/elements/Table/Cell/index.js';
 import { Type } from '../../components/elements/Table/Cell/types.js';
 import { Table } from '../../components/elements/Table/index.js';
 import { ComposeWrapper } from '../../components/utilities/ComposeWrapper/index.js';
@@ -23,7 +25,10 @@ const RolePageImpl: React.FC = () => {
     { field: 'updated_at', label: t('updated_at'), type: Type.Date },
   ];
 
-  const columns = buildColumns(fields);
+  const columns = buildColumns(fields, (i: number, row: Role, data: any) => {
+    const cell = <Cell colIndex={i} type={fields[i].type} cellData={data} />;
+    return i === 0 ? <RouterLink to={`${row.id}`}>{cell}</RouterLink> : cell;
+  });
 
   return (
     <Stack rowGap={3}>

--- a/src/admin/pages/User/index.tsx
+++ b/src/admin/pages/User/index.tsx
@@ -29,29 +29,25 @@ const UserPageImpl: React.FC = () => {
   ];
 
   const columns = buildColumns(fields, (i: number, row: User, data: any) => {
+    const defaultCell = <Cell colIndex={i} type={fields[i].type} cellData={data} />;
+
     switch (fields[i].field) {
       case 'name':
         return (
           <Cell
             colIndex={i}
             type={fields[i].type}
-            rowData={row}
             cellData={`${row.last_name} ${row.first_name}`}
           />
         );
       case 'api_key':
-        return (
-          <Cell
-            colIndex={i}
-            type={fields[i].type}
-            rowData={row}
-            cellData={row.api_key && t('valid')}
-          />
-        );
+        return <Cell colIndex={i} type={fields[i].type} cellData={row.api_key && t('valid')} />;
       case 'role':
-        return <Cell colIndex={i} type={fields[i].type} rowData={row} cellData={row.role?.name} />;
+        return <Cell colIndex={i} type={fields[i].type} cellData={row.role?.name} />;
+      case 'user_name':
+        return <RouterLink to={`${row.id}`}>{defaultCell}</RouterLink>;
       default:
-        return <Cell colIndex={i} type={fields[i].type} rowData={row} cellData={data} />;
+        return defaultCell;
     }
   });
 

--- a/src/admin/pages/collections/List/Default.tsx
+++ b/src/admin/pages/collections/List/Default.tsx
@@ -27,9 +27,12 @@ const DefaultListPageImpl: React.FC<Props> = ({ collection }) => {
   useEffect(() => {
     if (metaFields === undefined) return;
     const columnFields = buildColumnFields(metaFields);
-    const columns = buildColumns(columnFields, (i: number, row: any, data: any) => (
-      <Cell colIndex={i} type={columnFields[i].type} rowData={row} cellData={data} />
-    ));
+
+    const columns = buildColumns(columnFields, (i: number, row: any, data: any) => {
+      const cell = <Cell colIndex={i} type={columnFields[i].type} cellData={data} />;
+      return i === 0 ? <RouterLink to={`${row.id}`}>{cell}</RouterLink> : cell;
+    });
+
     setColumns(columns);
   }, [metaFields]);
 


### PR DESCRIPTION
## 背景
CheckboxTable, RadioGroupTable とテーブルの派生コンポーネントが増えているが、セル内で自動生成している相対パスのリンクが不要になるケースがある

## 何をしたか
- テーブルセルで自動生成するリンクを削除して、customRenderCell で個別に実装可能にした
- rowData 使わなくなったのでパラメータから削除