### PR TITLE
feat: Singleton データに one-to-many リレーションコンテンツを追加する

### DIFF
--- a/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/index.tsx
+++ b/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/index.tsx
@@ -28,7 +28,7 @@ const AddExistContentsImpl: React.FC<Props> = ({
   const { getRelations, getContents, getFields } = useContent();
   const { data: relations } = getRelations(collection, field);
   const relationFetched = (relations && relations[0] !== null) || false;
-  const { data: contents } = getContents(
+  const { data: contents }: { data: any[] } = getContents(
     relations ? relations[0].many_collection : '',
     relationFetched
   );

--- a/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/index.tsx
+++ b/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/index.tsx
@@ -9,7 +9,6 @@ import {
 } from '../../../../../pages/collections/Context/index.js';
 import { buildColumnFields } from '../../../../../pages/collections/List/buildColumnFields.js';
 import { buildColumns } from '../../../../../utilities/buildColumns.js';
-import { Cell } from '../../../../elements/Table/Cell/index.js';
 import { CheckBoxTable } from '../../../../elements/Table/CheckBoxTable/index.js';
 import { Column } from '../../../../elements/Table/types.js';
 import { ComposeWrapper } from '../../../../utilities/ComposeWrapper/index.js';
@@ -92,9 +91,7 @@ const AddExistContentsImpl: React.FC<Props> = ({
             </Box>
           </Stack>
           <Stack rowGap={3} sx={{ p: 2 }}>
-            {contents !== undefined && (
-              <CheckBoxTable columns={columns} rows={contents} onChange={handleCheck} />
-            )}
+            <CheckBoxTable columns={columns} rows={contents || []} onChange={handleCheck} />
           </Stack>
           <Stack sx={{ p: 2 }}>
             <Button

--- a/src/admin/components/forms/fieldTypes/SelectDropdownManyToOne/AddExistContents/index.tsx
+++ b/src/admin/components/forms/fieldTypes/SelectDropdownManyToOne/AddExistContents/index.tsx
@@ -28,11 +28,9 @@ const AddExistContentsImpl: React.FC<Props> = ({
   const { getRelations, getContents, getFields } = useContent();
   const { data: relations } = getRelations(collection, field);
   const relationFetched = (relations && relations[0] !== null) || false;
-  const { data: contents } = getContents(
-    relations ? relations[0].one_collection : '',
-    relationFetched
-  );
   const { data: fields } = getFields(relations ? relations[0].one_collection : '', relationFetched);
+  const { data } = getContents(relations ? relations[0].one_collection : '', relationFetched);
+  const contents = data && !Array.isArray(data) ? [data] : data;
 
   useEffect(() => {
     if (fields === undefined) return;

--- a/src/admin/components/forms/fieldTypes/SelectDropdownManyToOne/AddExistContents/index.tsx
+++ b/src/admin/components/forms/fieldTypes/SelectDropdownManyToOne/AddExistContents/index.tsx
@@ -9,7 +9,6 @@ import {
 } from '../../../../../pages/collections/Context/index.js';
 import { buildColumnFields } from '../../../../../pages/collections/List/buildColumnFields.js';
 import { buildColumns } from '../../../../../utilities/buildColumns.js';
-import { Cell } from '../../../../elements/Table/Cell/index.js';
 import { RadioGroupTable } from '../../../../elements/Table/RadioGroupTable/index.js';
 import { Column } from '../../../../elements/Table/types.js';
 import { ComposeWrapper } from '../../../../utilities/ComposeWrapper/index.js';
@@ -83,9 +82,7 @@ const AddExistContentsImpl: React.FC<Props> = ({
             </Box>
           </Stack>
           <Stack rowGap={3} sx={{ p: 2 }}>
-            {contents !== undefined && (
-              <RadioGroupTable columns={columns} rows={contents} onChange={handleSelect} />
-            )}
+            <RadioGroupTable columns={columns} rows={contents || []} onChange={handleSelect} />
           </Stack>
           <Stack sx={{ p: 2 }}>
             <Button

--- a/src/admin/pages/collections/Context/index.tsx
+++ b/src/admin/pages/collections/Context/index.tsx
@@ -15,7 +15,7 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
   ): SWRResponse =>
     useSWR(
       canFetch ? `/collections/${collection}/contents` : null,
-      (url) => api.get<{ contents: unknown[] }>(url).then((res) => res.data.contents),
+      (url) => api.get(url).then((res) => res.data.data),
       config
     );
 
@@ -85,7 +85,6 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
   const value = useMemo(
     () => ({
       getContents,
-      getSingletonContent,
       getContent,
       getFields,
       getPreviewContents,
@@ -97,7 +96,6 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
     }),
     [
       getContents,
-      getSingletonContent,
       getContent,
       getFields,
       getPreviewContents,

--- a/src/admin/pages/collections/Context/index.tsx
+++ b/src/admin/pages/collections/Context/index.tsx
@@ -19,17 +19,6 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
       config
     );
 
-  const getSingletonContent = (
-    collection: string,
-    canFetch: boolean = true,
-    config?: SWRConfiguration
-  ): SWRResponse =>
-    useSWR(
-      canFetch ? `/collections/${collection}/contents` : null,
-      (url) => api.get<{ content: unknown }>(url).then((res) => res.data.content),
-      config
-    );
-
   const getContent = (collection: string, id: string | null): SWRMutationResponse =>
     useSWRMutation(id ? `/collections/${collection}/contents/${id}` : null, (url) =>
       api.get<{ content: unknown }>(url).then((res) => res.data.content)

--- a/src/admin/pages/collections/Context/types.ts
+++ b/src/admin/pages/collections/Context/types.ts
@@ -3,11 +3,12 @@ import { SWRMutationResponse } from 'swr/mutation';
 import { Field, File, Relation } from '../../../../config/types.js';
 
 export type ContentContext = {
+  // If the collection model is a singleton, return any.
   getContents: (
     collection: string,
     canFetch?: boolean,
     config?: SWRConfiguration
-  ) => SWRResponse<any[]>;
+  ) => SWRResponse<any | any[]>;
   getSingletonContent: (
     collection: string,
     canFetch?: boolean,

--- a/src/admin/pages/collections/Context/types.ts
+++ b/src/admin/pages/collections/Context/types.ts
@@ -9,11 +9,6 @@ export type ContentContext = {
     canFetch?: boolean,
     config?: SWRConfiguration
   ) => SWRResponse<any | any[]>;
-  getSingletonContent: (
-    collection: string,
-    canFetch?: boolean,
-    config?: SWRConfiguration
-  ) => SWRResponse<any>;
   getContent: (collection: string, id: string | null) => SWRMutationResponse<any>;
   getFields: (
     collection: string,

--- a/src/admin/pages/collections/List/Singleton.tsx
+++ b/src/admin/pages/collections/List/Singleton.tsx
@@ -16,10 +16,10 @@ const SingletonPageImpl: React.FC<Props> = ({ collection }) => {
   const { hasPermission } = useAuth();
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();
-  const { getSingletonContent, getFields, createContent, updateContent } = useContent();
+  const { getContents, getFields, createContent, updateContent } = useContent();
   const { data: metaFields } = getFields(collection.collection);
   const fieldFetched = metaFields !== undefined;
-  const { data: content } = getSingletonContent(collection.collection, fieldFetched);
+  const { data: content } = getContents(collection.collection, fieldFetched);
 
   const { trigger: createTrigger, isMutating: isCreateMutating } = createContent(
     collection.collection

--- a/src/server/controllers/contents.ts
+++ b/src/server/controllers/contents.ts
@@ -24,10 +24,10 @@ router.get(
 
     if (collection.singleton) {
       const content = await contentsRepository.readSingleton(collectionName, conditions);
-      res.json({ content });
+      res.json({ data: content });
     } else {
       const contents = await contentsRepository.read(conditions);
-      res.json({ contents: contents });
+      res.json({ data: contents });
     }
   })
 );

--- a/src/server/controllers/contents.ts
+++ b/src/server/controllers/contents.ts
@@ -17,13 +17,18 @@ router.get(
   collectionPermissionsHandler('read'),
   asyncHandler(async (req: Request, res: Response) => {
     const collectionName = req.params.collection;
-    const repository = new ContentsRepository(collectionName);
+    const contentsRepository = new ContentsRepository(collectionName);
 
     const conditions = await makeConditions(req, collectionName);
-    const contents = await repository.read(conditions);
     const collection = await readCollection(collectionName);
 
-    res.json(collection.singleton ? { content: contents[0] } : { contents: contents });
+    if (collection.singleton) {
+      const content = await contentsRepository.readSingleton(collectionName, conditions);
+      res.json({ content });
+    } else {
+      const contents = await contentsRepository.read(conditions);
+      res.json({ contents: contents });
+    }
   })
 );
 
@@ -33,13 +38,14 @@ router.get(
   asyncHandler(async (req: Request, res: Response) => {
     const collectionName = req.params.collection;
     const id = Number(req.params.id);
+    const contentsRepository = new ContentsRepository(collectionName);
 
     const conditions = await makeConditions(req, collectionName);
     const content = await readContent(collectionName, { ...conditions, id });
     if (!content) throw new RecordNotFoundException('record_not_found');
 
     // relational contents (one-to-many)
-    const relationalContents = await readRelationalContents(id, collectionName);
+    const relationalContents = await contentsRepository.readRelationalContents(id, collectionName);
 
     res.json({
       content: {
@@ -179,33 +185,6 @@ async function readCollection(collectionName: string) {
   if (!collection) throw new RecordNotFoundException('record_not_found');
 
   return collection;
-}
-
-// Get the relational contents of the collection.
-async function readRelationalContents(contentId: number, collectionName: string) {
-  const fieldsRepository = new FieldsRepository();
-  const relationsRepository = new RelationsRepository();
-  const fields = await fieldsRepository.read({ collection: collectionName });
-
-  const relationalContents: Record<string, any> = {};
-  const referencedFields = fields.filter((field) => referencedTypes.includes(field.interface));
-  for (let field of referencedFields) {
-    const relations = await relationsRepository.read({
-      one_collection: field.collection,
-      one_field: field.field,
-    });
-    if (!relations[0]) return;
-
-    const contentsRepository = new ContentsRepository(relations[0].many_collection);
-
-    const params: Record<string, any> = {};
-    params[relations[0].many_field] = contentId;
-
-    const contents = await contentsRepository.read(params);
-    relationalContents[field.field] = contents;
-  }
-
-  return relationalContents;
 }
 
 // Get the status field and value from the collection.

--- a/src/server/repositories/contents.ts
+++ b/src/server/repositories/contents.ts
@@ -1,4 +1,7 @@
+import { referencedTypes } from '../database/schemas.js';
 import { BaseRepository, BaseTransaction } from './base.js';
+import { FieldsRepository } from './fields.js';
+import { RelationsRepository } from './relations.js';
 
 export class ContentsRepository extends BaseRepository<any> {
   transacting(trx: BaseTransaction): ContentsRepository {
@@ -6,5 +9,47 @@ export class ContentsRepository extends BaseRepository<any> {
       knex: trx.transaction,
     });
     return repositoryTransaction;
+  }
+
+  // Read content as singleton.
+  async readSingleton(collectionName: string, data: Record<string, any>) {
+    const contents = await this.read(data);
+    const content = contents[0];
+    if (!content) return content;
+
+    // relational contents (one-to-many)
+    const relationalContents = await this.readRelationalContents(content.id, collectionName);
+
+    return {
+      ...content,
+      ...relationalContents,
+    };
+  }
+
+  // Get the relational contents of the collection.
+  async readRelationalContents(contentId: number, collectionName: string) {
+    const fieldsRepository = new FieldsRepository();
+    const relationsRepository = new RelationsRepository();
+    const fields = await fieldsRepository.read({ collection: collectionName });
+
+    const relationalContents: Record<string, any> = {};
+    const referencedFields = fields.filter((field) => referencedTypes.includes(field.interface));
+    for (let field of referencedFields) {
+      const relations = await relationsRepository.read({
+        one_collection: field.collection,
+        one_field: field.field,
+      });
+      if (!relations[0]) return;
+
+      const contentsRepository = new ContentsRepository(relations[0].many_collection);
+
+      const params: Record<string, any> = {};
+      params[relations[0].many_field] = contentId;
+
+      const contents = await contentsRepository.read(params);
+      relationalContents[field.field] = contents;
+    }
+
+    return relationalContents;
   }
 }


### PR DESCRIPTION
## 何をしたか
- Singleton データに one-to-many リレーションコンテンツを追加する
- リファクタ
  - getContents の戻り値を any または any[] に変更
    - 呼び出し時点ではなく受信データで判定できるようにする
  - getSingletonContent は不要になるので削除