### PR TITLE
refactor: one-to-many フィールドの削除に対応した

### DIFF
--- a/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/index.tsx
+++ b/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/index.tsx
@@ -18,6 +18,7 @@ import { Props } from './types.js';
 const AddExistContentsImpl: React.FC<Props> = ({
   collection,
   field,
+  excludes,
   openState,
   onSuccess,
   onClose,
@@ -45,6 +46,10 @@ const AddExistContentsImpl: React.FC<Props> = ({
     const columns = buildColumns(columnFields);
     setColumns(columns);
   }, [fields]);
+
+  const excludedContents = contents
+    ? contents.filter((content) => !excludes.some((data) => data.id === content.id))
+    : [];
 
   const handleCheck = (row: any, checked: boolean) => {
     if (checked) {
@@ -91,7 +96,7 @@ const AddExistContentsImpl: React.FC<Props> = ({
             </Box>
           </Stack>
           <Stack rowGap={3} sx={{ p: 2 }}>
-            <CheckBoxTable columns={columns} rows={contents || []} onChange={handleCheck} />
+            <CheckBoxTable columns={columns} rows={excludedContents} onChange={handleCheck} />
           </Stack>
           <Stack sx={{ p: 2 }}>
             <Button

--- a/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/types.ts
+++ b/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/types.ts
@@ -1,7 +1,8 @@
 export type Props = {
+  openState: boolean;
   collection: string;
   field: string;
-  openState: boolean;
+  excludes: Partial<{ id: number }>[];
   onSuccess: (contents: Partial<{ id: number }>[]) => void;
   onClose: () => void;
 };

--- a/src/admin/components/forms/fieldTypes/ListOneToMany/index.tsx
+++ b/src/admin/components/forms/fieldTypes/ListOneToMany/index.tsx
@@ -1,4 +1,5 @@
-import { Box, Button } from '@mui/material';
+import { Cancel } from '@mui/icons-material';
+import { Box, Button, IconButton } from '@mui/material';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ContentContextProvider } from '../../../../pages/collections/Context/index.js';
@@ -19,9 +20,17 @@ export const ListOneToManyTypeImpl: React.FC<Props> = ({
     setAddRelationsOpen(state);
   };
 
-  const handleSelectedContents = (contents: Partial<{ id: number }>[]) => {
+  const handleSelectContents = (contents: Partial<{ id: number }>[]) => {
     setAddRelationsOpen(false);
-    setValue(meta.field, contents);
+    const selectedContents = (watch(meta.field) as Partial<{ id: number }>[]) || [];
+    selectedContents.push(...contents);
+    setValue(meta.field, selectedContents);
+  };
+
+  const removeSelectedContent = (contentId: number) => {
+    const selectedContents = watch(meta.field) as Partial<{ id: number }>[];
+    const filtered = selectedContents.filter((content) => content.id !== contentId);
+    setValue(meta.field, filtered);
   };
 
   return (
@@ -29,12 +38,20 @@ export const ListOneToManyTypeImpl: React.FC<Props> = ({
       <AddExistContents
         collection={meta.collection}
         field={meta.field}
+        excludes={watch(meta.field) || []}
         openState={addRelationsOpen}
-        onSuccess={(contents) => handleSelectedContents(contents)}
+        onSuccess={(contents) => handleSelectContents(contents)}
         onClose={() => onToggleAddRelations(false)}
       />
       {watch(meta.field) &&
-        watch(meta.field).map((data: any) => <Box key={data.id}>{data.id}</Box>)}
+        watch(meta.field).map((data: any) => (
+          <Box key={data.id} display="flex" alignItems="center">
+            {data.id}
+            <IconButton onClick={() => removeSelectedContent(data.id)}>
+              <Cancel />
+            </IconButton>
+          </Box>
+        ))}
       <Button
         variant="contained"
         onClick={() => onToggleAddRelations(true)}

--- a/src/server/database/overview.ts
+++ b/src/server/database/overview.ts
@@ -6,6 +6,10 @@ import { getSchemaInfo } from './inspector.js';
 export type CollectionOverview = {
   collection: string;
   singleton: boolean;
+  statusField: string | null;
+  draftValue: string | null;
+  publishValue: string | null;
+  archiveValue: string | null;
   fields: {
     [name: string]: FieldOverview;
   };
@@ -54,6 +58,10 @@ export const getSchemaOverview = async (): Promise<SchemaOverview> => {
     result.collections[collection.collection] = {
       collection: collection.collection,
       singleton: collection.singleton,
+      statusField: collection.status_field,
+      draftValue: collection.draft_value,
+      publishValue: collection.publish_value,
+      archiveValue: collection.archive_value,
       fields: collectionFields,
     };
   }


### PR DESCRIPTION
## 何をしたか
- one-to-many フィールドの削除に対応した
  - one-to-many の選択一覧から追加済みのコンテンツを削除
  - 選択済みコンテンツの削除を実装
  - 選択されなくなったコンテンツの削除を実装
- overview に collection のステータスフィールドも追加
  - controller での引き直しを削除した