### PR TITLE
fix: 関連コンテンツからの one-to-many フィールドの削除に対応した 

### DIFF
--- a/src/admin/components/forms/fieldTypes/SelectDropdownManyToOne/index.tsx
+++ b/src/admin/components/forms/fieldTypes/SelectDropdownManyToOne/index.tsx
@@ -1,4 +1,5 @@
-import { Box, Button } from '@mui/material';
+import { Cancel } from '@mui/icons-material';
+import { Box, Button, IconButton } from '@mui/material';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ContentContextProvider } from '../../../../pages/collections/Context/index.js';
@@ -19,9 +20,13 @@ export const SelectDropdownManyToOneTypeImpl: React.FC<Props> = ({
     setAddRelationsOpen(state);
   };
 
-  const handleSelectedContent = (content: Partial<{ id: number }>) => {
+  const handleSelectContent = (content: Partial<{ id: number }>) => {
     setAddRelationsOpen(false);
     setValue(meta.field, content.id);
+  };
+
+  const removeSelectedContent = () => {
+    setValue(meta.field, null);
   };
 
   return (
@@ -30,10 +35,17 @@ export const SelectDropdownManyToOneTypeImpl: React.FC<Props> = ({
         collection={meta.collection}
         field={meta.field}
         openState={addRelationsOpen}
-        onSuccess={(content) => handleSelectedContent(content)}
+        onSuccess={(content) => handleSelectContent(content)}
         onClose={() => onToggleAddRelations(false)}
       />
-      {watch(meta.field) && <Box key={watch(meta.field)}>{watch(meta.field)}</Box>}
+      {watch(meta.field) && (
+        <Box key={watch(meta.field)} display="flex" alignItems="center">
+          {watch(meta.field)}
+          <IconButton onClick={() => removeSelectedContent()}>
+            <Cancel />
+          </IconButton>
+        </Box>
+      )}
       <Button
         variant="contained"
         onClick={() => onToggleAddRelations(true)}

--- a/src/server/controllers/contents.ts
+++ b/src/server/controllers/contents.ts
@@ -39,7 +39,7 @@ router.get(
     const contentsRepository = new ContentsRepository(collection);
 
     const conditions = await makeConditions(req, req.collection);
-    const content = await readContent(collection, { ...conditions, id });
+    const content = (await contentsRepository.read({ ...conditions, id }))[0];
     if (!content) throw new RecordNotFoundException('record_not_found');
 
     // relational contents (one-to-many)
@@ -166,11 +166,6 @@ const fieldsFilteredAlias = (fields: FieldOverview[]) =>
     .reduce((acc: string[], field): string[] => {
       return [...acc, field.field];
     }, []);
-
-const readContent = async (collectionName: string, conditions: Partial<any>): Promise<unknown> => {
-  const repository = new ContentsRepository(collectionName);
-  return (await repository.read(conditions))[0];
-};
 
 // Get the status field and value from the collection.
 const makeConditions = async (req: Request, collection: CollectionOverview) => {

--- a/src/server/controllers/contents.ts
+++ b/src/server/controllers/contents.ts
@@ -5,7 +5,6 @@ import { CollectionOverview, FieldOverview } from '../database/overview.js';
 import { asyncHandler } from '../middleware/asyncHandler.js';
 import { collectionExists } from '../middleware/collectionExists.js';
 import { collectionPermissionsHandler } from '../middleware/permissionsHandler.js';
-import { BaseTransaction } from '../repositories/base.js';
 import { ContentsRepository } from '../repositories/contents.js';
 
 const router = express.Router();
@@ -80,13 +79,10 @@ router.post(
         if (postContentData) {
           const postContentIds = postContentData.map((manyCollection: any) => manyCollection.id);
 
-          await saveOneToMany(
-            contentId,
-            relation.relatedCollection,
-            relation.relatedField,
-            postContentIds,
-            tx
-          );
+          const repository = new ContentsRepository(relation.relatedCollection);
+          await repository
+            .transacting(tx)
+            .saveOneToMany(contentId, relation.relatedField, postContentIds);
         }
       }
 
@@ -123,13 +119,8 @@ router.patch(
         if (postContentData) {
           const postContentIds = postContentData.map((manyCollection: any) => manyCollection.id);
 
-          await saveOneToMany(
-            id,
-            relation.relatedCollection,
-            relation.relatedField,
-            postContentIds,
-            tx
-          );
+          const repository = new ContentsRepository(relation.relatedCollection);
+          await repository.transacting(tx).saveOneToMany(id, relation.relatedField, postContentIds);
         }
       }
 
@@ -192,29 +183,6 @@ const makeConditions = async (req: Request, collection: CollectionOverview) => {
   }
 
   return conditions;
-};
-
-const saveOneToMany = async (
-  contentId: number,
-  relatedCollection: string,
-  relatedField: string,
-  postRelatedContentIds: number[],
-  tx: BaseTransaction
-) => {
-  const repository = new ContentsRepository(relatedCollection);
-
-  // to null
-  const contents = await repository.transacting(tx).read({ [relatedField]: contentId });
-  for (let content of contents) {
-    if (!postRelatedContentIds.includes(content.id)) {
-      await repository.transacting(tx).update(content.id, { [relatedField]: null });
-    }
-  }
-
-  // save
-  for (let id of postRelatedContentIds) {
-    await repository.transacting(tx).update(id, { [relatedField]: contentId });
-  }
 };
 
 export const contents = router;

--- a/src/server/repositories/contents.ts
+++ b/src/server/repositories/contents.ts
@@ -52,4 +52,19 @@ export class ContentsRepository extends BaseRepository<any> {
 
     return relationalContents;
   }
+
+  // Saves one-to-many relations. If unselected, set null to foreign key.
+  async saveOneToMany(contentId: number, relatedField: string, postRelatedContentIds: number[]) {
+    const contents = await this.read({ [relatedField]: contentId });
+    for (let content of contents) {
+      if (!postRelatedContentIds.includes(content.id)) {
+        // Unselected, set null to foreign key.
+        await this.update(content.id, { [relatedField]: null });
+      }
+    }
+
+    for (let id of postRelatedContentIds) {
+      await this.update(id, { [relatedField]: contentId });
+    }
+  }
 }

--- a/src/utilities/pick.ts
+++ b/src/utilities/pick.ts
@@ -1,10 +1,11 @@
 // This function returns a new object with only the specified keys picked from the original object.
 // Alternatives to lodash _.pick.
 // ref: https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_pick
-export function pick(obj: any, ...keys: string[][]) {
-  const ret: Record<string, any> = {};
-  keys.flat().forEach((key) => {
-    if (obj[key]) ret[key] = obj[key];
-  });
-  return ret;
+export function pick(object: any, keys: string[]) {
+  return keys.reduce((acc: Record<string, any>, key) => {
+    if (object && object.hasOwnProperty(key)) {
+      acc[key] = object[key];
+    }
+    return acc;
+  }, {});
 }


### PR DESCRIPTION
## 関連PR
https://github.com/superfastcms/superfast/pull/602

## 何をしたか
- 関連コンテンツからの one-to-many フィールドの削除に対応した 
  - 実装漏れ
- リファクタ
  - saveOneToMany を repository に移動
  - pick の実装をリファクタ