### PR TITLE
refactor: コンテンツ取得時に one-to-many リレーション関係のデータも合わせて返す。

### DIFF
--- a/src/admin/components/elements/Nav/index.tsx
+++ b/src/admin/components/elements/Nav/index.tsx
@@ -146,13 +146,13 @@ const NavModuleBar = () => {
           zIndex: theme.zIndex.appBar + 100,
         }}
       >
-        <NavIcon>
-          <Tooltip title={t('logout')} placement="right">
-            <IconButton onClick={() => setIsDialogOpen(true)}>
+        <Link onClick={() => setIsDialogOpen(true)}>
+          <NavIcon>
+            <Tooltip title={t('logout')} placement="right">
               <LogoutOutlined />
-            </IconButton>
-          </Tooltip>
-        </NavIcon>
+            </Tooltip>
+          </NavIcon>
+        </Link>
         <Link component={RouterLink} to="/admin/me">
           <NavIcon>
             <Tooltip title="Me" placement="right">

--- a/src/admin/components/elements/Table/Cell/index.tsx
+++ b/src/admin/components/elements/Table/Cell/index.tsx
@@ -27,6 +27,10 @@ export const Cell: React.FC<Props> = (props) => {
         return castToBoolean(cellData) ? t('enabled') : t('disabled');
       case Type.Object:
         return JSON.stringify(cellData);
+      case Type.Array:
+        const data = cellData as Partial<{ id: number }>[];
+        const ids = data.map((item) => item.id).join(', ');
+        return ids ? '[' + ids + ']' : '';
       default:
         return '';
     }

--- a/src/admin/components/elements/Table/Cell/types.ts
+++ b/src/admin/components/elements/Table/Cell/types.ts
@@ -5,6 +5,7 @@ export const Type = {
   Object: 'object',
   Status: 'status',
   Boolean: 'boolean',
+  Array: 'array',
 } as const;
 
 export type Props = {

--- a/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/index.tsx
+++ b/src/admin/components/forms/fieldTypes/ListOneToMany/AddExistContents/index.tsx
@@ -29,14 +29,18 @@ const AddExistContentsImpl: React.FC<Props> = ({
   const { getRelations, getContents, getFields } = useContent();
   const { data: relations } = getRelations(collection, field);
   const relationFetched = (relations && relations[0] !== null) || false;
-  const { data: contents }: { data: any[] } = getContents(
-    relations ? relations[0].many_collection : '',
-    relationFetched
-  );
+
   const { data: fields } = getFields(
     relations ? relations[0].many_collection : '',
     relationFetched
   );
+
+  const { data: content } = getContents(
+    relations ? relations[0].many_collection : '',
+    relationFetched
+  );
+  // Convert to array in case of singleton.
+  const contents: any[] = content && !Array.isArray(content) ? [content] : content;
 
   useEffect(() => {
     if (fields === undefined) return;

--- a/src/admin/components/forms/fieldTypes/SelectDropdownManyToOne/AddExistContents/index.tsx
+++ b/src/admin/components/forms/fieldTypes/SelectDropdownManyToOne/AddExistContents/index.tsx
@@ -28,9 +28,15 @@ const AddExistContentsImpl: React.FC<Props> = ({
   const { getRelations, getContents, getFields } = useContent();
   const { data: relations } = getRelations(collection, field);
   const relationFetched = (relations && relations[0] !== null) || false;
+
   const { data: fields } = getFields(relations ? relations[0].one_collection : '', relationFetched);
-  const { data } = getContents(relations ? relations[0].one_collection : '', relationFetched);
-  const contents = data && !Array.isArray(data) ? [data] : data;
+
+  const { data: content } = getContents(
+    relations ? relations[0].one_collection : '',
+    relationFetched
+  );
+  // Convert to array in case of singleton.
+  const contents = content && !Array.isArray(content) ? [content] : content;
 
   useEffect(() => {
     if (fields === undefined) return;

--- a/src/admin/pages/collections/Context/index.tsx
+++ b/src/admin/pages/collections/Context/index.tsx
@@ -21,7 +21,7 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
 
   const getContent = (collection: string, id: string | null): SWRMutationResponse =>
     useSWRMutation(id ? `/collections/${collection}/contents/${id}` : null, (url) =>
-      api.get<{ content: unknown }>(url).then((res) => res.data.content)
+      api.get<{ data: any }>(url).then((res) => res.data.data)
     );
 
   const getFields = (
@@ -37,7 +37,7 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
 
   const getPreviewContents = (collection: string): SWRMutationResponse =>
     useSWRMutation(`/collections/${collection}/contents`, async (url: string, { arg }) => {
-      return api.get<{ contents: unknown[] }>(url, arg).then((res) => res.data.contents);
+      return api.get<{ contents: any[] }>(url, arg).then((res) => res.data.contents);
     });
 
   const createContent = (collection: string) =>

--- a/src/admin/pages/collections/List/buildColumnFields.ts
+++ b/src/admin/pages/collections/List/buildColumnFields.ts
@@ -18,9 +18,10 @@ const toType = (fieldInterface: string): (typeof Type)[keyof typeof Type] => {
   switch (fieldInterface) {
     case 'input':
     case 'inputMultiline':
-    // case 'inputRichTextHtml':
-    // case 'inputRichTextMd':
+    case 'inputRichTextMd':
+    case 'fileImage':
     case 'selectDropdown':
+    case 'selectDropdownManyToOne':
       return Type.Text;
     case 'selectDropdownStatus':
       return Type.Status;
@@ -28,7 +29,9 @@ const toType = (fieldInterface: string): (typeof Type)[keyof typeof Type] => {
       return Type.Boolean;
     case 'dateTime':
       return Type.Date;
+    case 'listOneToMany':
+      return Type.Array;
     default:
-      return Type.Text;
+      return Type.Object;
   }
 };


### PR DESCRIPTION
## 何をしたか
- コンテンツ取得時に、one-to-manyリレーション関係のデータも合わせて返す実装を追加した
- リファクタ
  - ログアウトのボタン要素の入れ子関係を修正
  - リレーション先のコレクションが singleton の場合の考慮を追加