### PR TITLE
bug: ユーザーの単票取得時に0を指定すると1件目が取得できる不具合を修正

### DIFF
--- a/src/server/controllers/users.ts
+++ b/src/server/controllers/users.ts
@@ -37,7 +37,7 @@ router.get(
     const id = Number(req.params.id);
     const repository = new UsersRepository();
 
-    const user = await repository.readOneWithRole({ id });
+    const user = await repository.readOneWithRole(id);
     if (!user) throw new RecordNotFoundException('record_not_found');
 
     res.json({

--- a/src/server/controllers/users.ts
+++ b/src/server/controllers/users.ts
@@ -15,11 +15,7 @@ const router = express.Router();
 router.get(
   '/users',
   permissionsHandler([{ collection: 'superfast_users', action: 'read' }]),
-  asyncHandler(async (req: Request, res: Response) => {
-    if (!req.userId) {
-      throw new InvalidCredentialsException('invalid_user_credentials');
-    }
-
+  asyncHandler(async (_req: Request, res: Response) => {
     const repository = new UsersRepository();
 
     const users = await repository.readWithRole();
@@ -84,10 +80,6 @@ router.delete(
   asyncHandler(async (req: Request, res: Response) => {
     const id = Number(req.params.id);
     const usersRepository = new UsersRepository();
-
-    if (!req.userId) {
-      throw new InvalidCredentialsException('invalid_user_credentials');
-    }
 
     if (req.userId === id) {
       throw new UnprocessableEntityException('can_not_delete_itself');

--- a/src/server/controllers/users.ts
+++ b/src/server/controllers/users.ts
@@ -163,7 +163,7 @@ const payload = (user: any) => {
     user_name: user.user_name,
     email: user.email,
     is_active: user.is_active,
-    api_key: user.api_key,
+    api_key: user.api_key ? '********' : null,
     updated_at: user.updated_at,
     role: {
       id: user.role_id,

--- a/src/server/repositories/users.ts
+++ b/src/server/repositories/users.ts
@@ -50,10 +50,10 @@ export class UsersRepository extends BaseRepository<User> {
   readOneWithRole(id: number): Promise<User> {
     return this.queryBuilder
       .select('u.*', {
-        roleId: 'r.id',
-        roleName: 'r.name',
-        roleDescription: 'r.description',
-        roleAdminAccess: 'r.admin_access',
+        role_id: 'r.id',
+        role_name: 'r.name',
+        role_description: 'r.description',
+        role_admin_access: 'r.admin_access',
       })
       .from('superfast_users AS u')
       .join('superfast_roles AS r', 'r.id', 'u.role_id')
@@ -78,8 +78,8 @@ export class UsersRepository extends BaseRepository<User> {
 
     return this.queryBuilder
       .select('u.id', 'u.user_name', 'u.password', 'u.api_key', {
-        roleId: 'r.id',
-        adminAccess: 'r.admin_access',
+        role_id: 'r.id',
+        admin_access: 'r.admin_access',
       })
       .from('superfast_users AS u')
       .join('superfast_roles AS r', 'r.id', 'u.role_id')

--- a/src/server/repositories/users.ts
+++ b/src/server/repositories/users.ts
@@ -47,17 +47,7 @@ export class UsersRepository extends BaseRepository<User> {
       .join('superfast_roles AS r', 'r.id', 'u.role_id');
   }
 
-  readOneWithRole(data: { id?: number; token?: string }): Promise<User> {
-    const condition: { [index: string]: any } = {};
-
-    if (data.id) {
-      condition['u.id'] = data.id;
-    }
-
-    if (data.token) {
-      condition['u.token'] = data.token;
-    }
-
+  readOneWithRole(id: number): Promise<User> {
     return this.queryBuilder
       .select('u.*', {
         roleId: 'r.id',
@@ -67,7 +57,7 @@ export class UsersRepository extends BaseRepository<User> {
       })
       .from('superfast_users AS u')
       .join('superfast_roles AS r', 'r.id', 'u.role_id')
-      .where(condition)
+      .where('u.id', id)
       .first();
   }
 


### PR DESCRIPTION
## 何をしたか
- `/user/:id` に0を指定すると1件目が取得できる不具合を修正
  - id 指定が分岐条件になっていたため 0 == false として扱われていた
- リファクタ
  - 重複するパーミッションチェックの削除
  - api_key のレスポンス結果をマスクする