### PR TITLE
トークンに含まれる秘匿情報を削除

### DIFF
--- a/src/admin/pages/collections/ApiPreview/index.tsx
+++ b/src/admin/pages/collections/ApiPreview/index.tsx
@@ -60,12 +60,9 @@ const ApiPreviewImpl: React.FC<Props> = ({ collection, singleton }) => {
           </Grid>
           <Stack>
             <Box>Headers</Box>
-            <Box>{user.apiKey ? `Bearer ${user.apiKey}` : '-'}</Box>
+            <Box>-</Box>
           </Stack>
-          <Paper elevation={0}>
-            {`curl "${url}" -H "Authorization: Bearer
-            ${user.apiKey}"`}
-          </Paper>
+          <Paper elevation={0}>{`curl "${url}" -H "Authorization: Bearer -`}</Paper>
           {contents && (
             <TextField
               multiline

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -25,17 +25,13 @@ export type Token = {
   token: string;
 };
 
-export type MeUser = {
+export type AuthUser = {
   id: number;
   roleId: number;
   userName: string;
-  password: string;
   adminAccess: boolean;
   appAccess: boolean | null; // access from applications.
-  apiKey: string | null;
 };
-
-export type AuthUser = Omit<MeUser, 'password'>;
 
 // /////////////////////////////////////
 // Error

--- a/src/server/controllers/authentications.ts
+++ b/src/server/controllers/authentications.ts
@@ -1,12 +1,11 @@
-import argon2 from 'argon2';
 import express, { Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
-import { MeUser } from '../../config/types.js';
+import { AuthUser } from '../../config/types.js';
 import { env } from '../../env.js';
-import { InvalidCredentialsException } from '../../exceptions/invalidCredentials.js';
 import { asyncHandler } from '../middleware/asyncHandler.js';
 import { permissionsHandler } from '../middleware/permissionsHandler.js';
 import { UsersRepository } from '../repositories/users.js';
+import { InvalidCredentialsException } from '../../exceptions/invalidCredentials.js';
 
 const router = express.Router();
 
@@ -15,11 +14,7 @@ router.post(
   asyncHandler(async (req: Request, res: Response) => {
     const repository = new UsersRepository();
 
-    const user = await repository.readMe({ email: req.body.email });
-    if (!user || !(await argon2.verify(user.password, req.body.password))) {
-      throw new InvalidCredentialsException('incorrect_email_or_password');
-    }
-
+    const user = await repository.login(req.body.email, req.body.password);
     const token = toToken(user);
 
     res.json({
@@ -35,6 +30,10 @@ router.get(
     const repository = new UsersRepository();
 
     const user = await repository.readMe({ id: Number(req.userId) });
+    if (!user) {
+      throw new InvalidCredentialsException('token_invalid_or_expired');
+    }
+
     const token = toToken(user);
 
     res.json({
@@ -43,10 +42,9 @@ router.get(
   })
 );
 
-const toToken = (user: MeUser) => {
-  const tokenizedUser: Omit<MeUser, 'password'> = { ...user };
-  tokenizedUser.appAccess = true;
-  const token = jwt.sign(tokenizedUser, env.SECRET, {
+const toToken = (user: AuthUser) => {
+  user.appAccess = true;
+  const token = jwt.sign(user, env.SECRET, {
     expiresIn: env.ACCESS_TOKEN_TTL,
   });
 

--- a/src/server/middleware/authHandler.ts
+++ b/src/server/middleware/authHandler.ts
@@ -4,28 +4,31 @@ import { UsersRepository } from '../repositories/users.js';
 import { decodeJwt } from '../utilities/decodeJwt.js';
 import { asyncHandler } from './asyncHandler.js';
 
-const _authHandler: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
-  const repository = new UsersRepository();
+export const authHandler: RequestHandler = asyncHandler(
+  async (req: Request, _res: Response, next: NextFunction) => {
+    const repository = new UsersRepository();
 
-  try {
-    if (req.token) {
-      const user = decodeJwt(req.token) || (await repository.readMe({ token: req.token }));
-      if (user) {
-        req.userId = user.id;
-        req.adminAccess = user.adminAccess;
-        req.roleId = user.roleId;
-        req.appAccess = user.appAccess ?? false;
-      } else {
-        return next(new InvalidCredentialsException('invalid_user_credentials'));
+    try {
+      if (req.token) {
+        // Check user from cookie or Bearer token.
+        const user = decodeJwt(req.token) || (await repository.readMe({ apiKey: req.token }));
+        if (user) {
+          req.userId = user.id;
+          req.adminAccess = user.adminAccess;
+          req.roleId = user.roleId;
+          req.appAccess = user.appAccess ?? false;
+        } else {
+          return next(new InvalidCredentialsException('invalid_user_credentials'));
+        }
       }
+
+      return next();
+    } catch (e) {
+      return next(
+        new InvalidCredentialsException('invalid_user_credentials', {
+          message: (e as Error).message,
+        })
+      );
     }
-
-    return next();
-  } catch (e) {
-    return next(
-      new InvalidCredentialsException('invalid_user_credentials', { message: (e as Error).message })
-    );
   }
-};
-
-export const authHandler = asyncHandler(_authHandler);
+);


### PR DESCRIPTION
## 何をしたか
- AuthUser（旧 MeUser） から apiKey, password を削除
- ログイン者情報取得とログイン用の関数を分離

## やらなかったこと
- API preview の apiKey を一旦削除（恒久対応は後続対応）