### PR TITLE
refactor: API previewのリファクタ

### DIFF
--- a/docs/pages/app-guides/config-options.mdx
+++ b/docs/pages/app-guides/config-options.mdx
@@ -16,12 +16,12 @@ MIGRATE_EXTENSIONS=".js"
 
 ## General
 
-| 変数名      | 説明                    | 初期値                  |
-| :---------- | :---------------------- | :---------------------- |
-| SERVER_URL  | Express サーバー URL    | `http://localhost:4000` |
-| SERVER_HOST | Express サーバー ホスト | `http://localhost`      |
-| SERVER_PORT | App Server ポート       | `4000`                  |
-| ADMIN_PORT  | App Admin ポート        | `4001`                  |
+| 変数名            | 説明                    | 初期値                  |
+| :---------------- | :---------------------- | :---------------------- |
+| PUBLIC_SERVER_URL | Express サーバー URL    | `http://localhost:4000` |
+| SERVER_HOST       | Express サーバー ホスト | `http://localhost`      |
+| SERVER_PORT       | App Server ポート       | `4000`                  |
+| ADMIN_PORT        | App Admin ポート        | `4001`                  |
 
 ## Storage
 

--- a/src/admin/components/utilities/Auth/index.tsx
+++ b/src/admin/components/utilities/Auth/index.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useMemo } from 'react';
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useSWR from 'swr';
 import useSWRMutation from 'swr/mutation';
@@ -10,6 +10,7 @@ import { AuthContext } from './types.js';
 const Context = createContext({} as AuthContext);
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [tokenInMemory, setTokenInMemory] = useState<string>();
   const navigate = useNavigate();
 
   const login = () =>
@@ -18,6 +19,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       async (url: string, { arg }: { arg: Record<string, any> }) => {
         return api.post<{ token: string; user: AuthUser }>(url, arg).then((res) => {
           setAuthorization(res.data.token);
+          setTokenInMemory(res.data.token);
           mutate(res.data);
           return res.data;
         });
@@ -29,6 +31,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       return api.post(url).then((res) => {
         removeAuthorization();
         mutate({ token: null, user: null }, false);
+        setTokenInMemory(undefined);
         return res;
       });
     });
@@ -68,6 +71,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       .then(({ data }) => {
         if (data.token) {
           setAuthorization(data.token);
+          setTokenInMemory(data.token);
         }
         return data;
       })
@@ -113,6 +117,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       hasPermission,
       login,
       logout,
+      token: tokenInMemory,
     }),
     [me, permissions, hasPermission, login, logout]
   );

--- a/src/admin/components/utilities/Auth/types.ts
+++ b/src/admin/components/utilities/Auth/types.ts
@@ -3,6 +3,7 @@ import { AuthUser, Permission, PermissionsAction } from '../../../../config/type
 
 export type AuthContext<T = AuthUser> = {
   user: T | null | undefined;
+  token?: string;
   permissions: Permission[] | null;
   hasPermission: (collection: string, action: PermissionsAction) => boolean;
   login: () => SWRMutationResponse<

--- a/src/admin/pages/collections/ApiPreview/index.tsx
+++ b/src/admin/pages/collections/ApiPreview/index.tsx
@@ -1,22 +1,22 @@
-import { Box, Button, Drawer, Paper, Stack, TextField, useTheme } from '@mui/material';
+import { Box, Button, Drawer, Stack, TextField, useTheme } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2/Grid2.js';
+import axios from 'axios';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../../components/utilities/Auth/index.js';
 import { ComposeWrapper } from '../../../components/utilities/ComposeWrapper/index.js';
-import { ContentContextProvider, useContent } from '../Context/index.js';
+import { ContentContextProvider } from '../Context/index.js';
 import { Props } from './types.js';
 
 const ApiPreviewImpl: React.FC<Props> = ({ collection, singleton }) => {
   const { t } = useTranslation();
   const theme = useTheme();
-  const { user } = useAuth();
+  const { token } = useAuth();
   const [open, setOpen] = useState(false);
-  const { getPreviewContents } = useContent();
-  const { data: contents, trigger, isMutating } = getPreviewContents(collection);
 
-  // TODO Make host an environment variable.
-  const url = `http://localhost:4000/api/collections/${collection}/contents`;
+  const url = `${process.env.PUBLIC_SERVER_URL}/api/collections/${collection}/contents`;
+
+  const [content, setContent] = useState<string | undefined>();
 
   const toggleDrawer = (open: boolean) => (event: React.KeyboardEvent | React.MouseEvent) => {
     if (
@@ -31,14 +31,16 @@ const ApiPreviewImpl: React.FC<Props> = ({ collection, singleton }) => {
   };
 
   const onFetch = async () => {
-    try {
-      await trigger();
-    } catch (error) {
-      console.error(error);
-    }
+    const result = await axios(url, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + token,
+      },
+    });
+    setContent(JSON.stringify(result.data, null, '\t'));
   };
-
-  if (!user) return <></>;
 
   return (
     <>
@@ -57,20 +59,20 @@ const ApiPreviewImpl: React.FC<Props> = ({ collection, singleton }) => {
               <Box sx={{ border: 1, p: 1 }}>{url}</Box>
             </Grid>
             <Grid>
-              <Button variant="contained" onClick={onFetch} disabled={isMutating}>
+              <Button variant="contained" onClick={onFetch}>
                 {t('fetch')}
               </Button>
             </Grid>
           </Grid>
           <Stack>
             <Box>Headers</Box>
-            <Box>-</Box>
+            <Box>{token}</Box>
           </Stack>
-          <Paper elevation={0}>{`curl "${url}" -H "Authorization: Bearer -`}</Paper>
-          {contents && (
+          <Box>{`curl "${url}" -H "Authorization: Bearer ${token}"`}</Box>
+          {content && (
             <TextField
               multiline
-              value={JSON.stringify(singleton ? contents[0] : contents, null, 2)}
+              value={content}
               InputProps={{
                 readOnly: true,
               }}

--- a/src/admin/pages/collections/Context/index.tsx
+++ b/src/admin/pages/collections/Context/index.tsx
@@ -35,11 +35,6 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
       config
     );
 
-  const getPreviewContents = (collection: string): SWRMutationResponse =>
-    useSWRMutation(`/collections/${collection}/contents`, async (url: string, { arg }) => {
-      return api.get<{ contents: any[] }>(url, arg).then((res) => res.data.contents);
-    });
-
   const createContent = (collection: string) =>
     useSWRMutation(
       `/collections/${collection}/contents`,
@@ -76,7 +71,6 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
       getContents,
       getContent,
       getFields,
-      getPreviewContents,
       createContent,
       updateContent,
       getFileImage,
@@ -87,7 +81,6 @@ export const ContentContextProvider: React.FC<{ children: React.ReactNode }> = (
       getContents,
       getContent,
       getFields,
-      getPreviewContents,
       createContent,
       updateContent,
       getFileImage,

--- a/src/admin/pages/collections/Context/types.ts
+++ b/src/admin/pages/collections/Context/types.ts
@@ -15,7 +15,6 @@ export type ContentContext = {
     canFetch?: boolean,
     config?: SWRConfiguration
   ) => SWRResponse<Field[]>;
-  getPreviewContents: (collection: string) => SWRMutationResponse<any[]>;
   createContent: (collection: string) => SWRMutationResponse<number, any, Record<string, any>, any>;
   updateContent: (
     collection: string,

--- a/src/env.ts
+++ b/src/env.ts
@@ -12,7 +12,7 @@ type AllowedEnvironmentVariable =
   // /////////////////////////////////////
   // General
   // /////////////////////////////////////
-  | 'SERVER_URL'
+  | 'PUBLIC_SERVER_URL'
   | 'SERVER_HOST'
   | 'SERVER_PORT'
   | 'ADMIN_PORT'
@@ -105,7 +105,7 @@ type AllowedEnvironmentVariable =
 
 export const defaults: Partial<Record<AllowedEnvironmentVariable, any>> = {
   // General
-  SERVER_URL: 'http://localhost:4000',
+  PUBLIC_SERVER_URL: 'http://localhost:4000',
   SERVER_HOST: 'http://localhost',
   SERVER_PORT: '4000',
   ADMIN_PORT: '4001',

--- a/src/server/controllers/users.ts
+++ b/src/server/controllers/users.ts
@@ -138,7 +138,7 @@ router.post(
     mail.sendEmail({
       to: user.email,
       subject: 'Reset Password',
-      html: `${env.SERVER_URL}/admin/auth/reset-password/${user.reset_password_token}`,
+      html: `${env.PUBLIC_SERVER_URL}/admin/auth/reset-password/${user.reset_password_token}`,
     });
 
     res.json({


### PR DESCRIPTION
## 何をしたか
- 認証後にアクセストークンをインメモリで保存し、preview 画面に表示
- `SERVER_URL` を UIでも利用するため `PUBLIC_SERVER_URL` に変更
- fetch 結果をプレビューに表示