### PR TITLE
fix: webpack の knex-schema-inspector が読み込まれないのを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superfastcms",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Free and Open-source Headless CMS and Application Framework built with TypeScript, Node.js, React.",
   "license": "MIT",
   "type": "module",

--- a/src/server/database/inspector.ts
+++ b/src/server/database/inspector.ts
@@ -1,4 +1,4 @@
-import schemaInspector from 'knex-schema-inspector';
+import { SchemaInspector } from 'knex-schema-inspector';
 import { getDatabase } from './connection.js';
 
 type SchemaInfo = {
@@ -23,7 +23,7 @@ type ColumnInfo = {
 };
 
 export const getSchemaInfo = async (): Promise<SchemaInfo> => {
-  const inspector = schemaInspector(getDatabase());
+  const inspector = SchemaInspector(getDatabase());
 
   const result: SchemaInfo = {};
 


### PR DESCRIPTION
## 何をしたか
- webpack の knex-schema-inspector が読み込まれない不具合を修正
- version 0.9.0 にインクリメント

## ref
https://github.com/chenbimo/yicode/blob/9c2f7ed9b071027d669d6f9d14003720776b8c4f/packages/yiapi/scripts/syncDatabase.js#L8