### PR TITLE
Removed version check command

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
-import packageJSON from '../package.json' assert { type: 'json' };
 import { scriptBuild } from './scripts/commands/build.js';
 import { scriptDev } from './scripts/commands/dev.js';
 import { scriptStart } from './scripts/commands/start.js';
@@ -38,16 +37,6 @@ program.storeOptionsAsProperties(false).allowUnknownOption(true);
 
 program.helpOption('-h, --help', 'Display help for command');
 program.addHelpCommand('help [command]', 'Display help for command');
-
-// `$ superfast version` (--version synonym)
-program.version(packageJSON.version, '-v, --version', 'Output the version number');
-program
-  .command('version')
-  .description('Output your version of Superfast')
-  .action(() => {
-    process.stdout.write(`${packageJSON.version}\n`);
-    process.exit(0);
-  });
 
 program
   .command('init')


### PR DESCRIPTION
## What?
Remove unused version check commands

## Why?
Because importing json outputs ExperimentalWarning during installation