### PR TITLE
Restyling snackbar (notistack)

### DIFF
--- a/src/admin/components/utilities/Snackbar/index.tsx
+++ b/src/admin/components/utilities/Snackbar/index.tsx
@@ -1,0 +1,48 @@
+import {
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  InfoCircleOutlined,
+  WarningOutlined,
+} from '@ant-design/icons';
+import { styled } from '@mui/material/styles';
+import { SnackbarProvider } from 'notistack';
+import React from 'react';
+
+// custom styles
+const StyledSnackbarProvider = styled(SnackbarProvider)(({ theme }) => ({
+  '&.notistack-MuiContent-default': {
+    backgroundColor: theme.palette.primary.main,
+  },
+  '&.notistack-MuiContent-error': {
+    backgroundColor: theme.palette.error.main,
+  },
+  '&.notistack-MuiContent-success': {
+    backgroundColor: theme.palette.success.main,
+  },
+  '&.notistack-MuiContent-info': {
+    backgroundColor: theme.palette.info.main,
+  },
+  '&.notistack-MuiContent-warning': {
+    backgroundColor: theme.palette.warning.main,
+  },
+}));
+
+export const Snackbar = ({ children }: any) => {
+  const style = { marginRight: 8, fontSize: '1.15rem' };
+
+  return (
+    <StyledSnackbarProvider
+      maxSnack={3}
+      anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+      iconVariant={{
+        success: <CheckCircleOutlined style={style} />,
+        error: <CloseCircleOutlined style={style} />,
+        warning: <WarningOutlined style={style} />,
+        info: <InfoCircleOutlined style={style} />,
+      }}
+      style={{ boxShadow: 'none' }}
+    >
+      {children}
+    </StyledSnackbarProvider>
+  );
+};

--- a/src/admin/index.tsx
+++ b/src/admin/index.tsx
@@ -1,4 +1,3 @@
-import { SnackbarProvider } from 'notistack';
 import React, { Suspense } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter as Router } from 'react-router-dom';
@@ -9,6 +8,7 @@ import { AuthProvider } from './components/utilities/Auth/index.js';
 import { ColorModeProvider } from './components/utilities/ColorMode/index.js';
 import { ConfigProvider } from './components/utilities/Config/index.js';
 import { SWRConfigure } from './components/utilities/SWRConfigure/index.js';
+import { Snackbar } from './components/utilities/Snackbar/index.js';
 import { ThemeCustomization } from './components/utilities/Theme/index.js';
 import lazy from './utilities/lazy.js';
 import 'simplebar-react/dist/simplebar.min.css';
@@ -20,7 +20,7 @@ const Index = () => (
     <ColorModeProvider>
       <ThemeCustomization>
         <Router>
-          <SnackbarProvider maxSnack={3} anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}>
+          <Snackbar>
             <SWRConfigure>
               <AuthProvider>
                 <ConfigProvider>
@@ -28,7 +28,7 @@ const Index = () => (
                 </ConfigProvider>
               </AuthProvider>
             </SWRConfigure>
-          </SnackbarProvider>
+          </Snackbar>
         </Router>
       </ThemeCustomization>
     </ColorModeProvider>


### PR DESCRIPTION
## What?
Restyling snackbar (notistack)

- Change to ant-design icon
- Set boxShadow to none

![スクリーンショット 2023-07-16 15 08 58](https://github.com/superfastcms/superfast/assets/59549200/7dcbe7f7-09c1-4ef8-8712-f044da6bc4c9)
![スクリーンショット 2023-07-16 15 09 13](https://github.com/superfastcms/superfast/assets/59549200/049027cf-ed6f-4899-831b-3f632c7f1d82)

<!--
Write a brief description of your commitments.
-->

## Why?
must

<!--
Write the need for the ticket.
-->