### PR TITLE
test: truncate test DB with teardown

### DIFF
--- a/src/api/database/migrations/20230209234825_add-init-schema.ts
+++ b/src/api/database/migrations/20230209234825_add-init-schema.ts
@@ -89,6 +89,14 @@ export const up = async (knex: Knex): Promise<void> => {
 };
 
 export const down = async (knex: Knex): Promise<void> => {
+  await knex.schema.table('superfast_permissions', (table) => {
+    table.dropForeign(['role_id']);
+  });
+
+  await knex.schema.table('superfast_users', (table) => {
+    table.dropForeign('role_id');
+  });
+
   await knex.schema
     .dropTable('superfast_roles')
     .dropTable('superfast_users')

--- a/test/setups/seeds/00_reset.ts
+++ b/test/setups/seeds/00_reset.ts
@@ -1,7 +1,0 @@
-import { Knex } from 'knex';
-
-export const seed = async (knex: Knex): Promise<void> => {
-  await knex('superfast_project_settings').del();
-  await knex('superfast_users').del();
-  await knex('superfast_roles').del();
-};

--- a/test/setups/teardown.ts
+++ b/test/setups/teardown.ts
@@ -1,5 +1,7 @@
 import { unlinkSync } from 'fs';
+import knex from 'knex';
 import { JestConfigWithTsJest } from 'ts-jest/dist/types.js';
+import { config } from '../config.js';
 import { testDatabases } from '../utilities/testDatabases.js';
 
 export default async function teardown(
@@ -12,8 +14,15 @@ export default async function teardown(
   console.log('🏁 Tests complete!\n');
 
   for (const testDatabase of testDatabases) {
+    const knexConfig = config.knexConfig[testDatabase]!;
+    const database = knex(knexConfig);
+
+    await database.migrate.rollback(knexConfig.migrations, true);
+
     if (testDatabase === 'sqlite3') {
       unlinkSync('test.db');
     }
+
+    await database.destroy();
   }
 }


### PR DESCRIPTION
## What?
Truncate test DB with teardown.

- Execute rollback all
- Fixed a problem with migrate down not working

<!--
Write a brief description of your commitments.
-->

## Why?
- Data initialization in a CI environment is a meaningless step (it is always initial)
- Clean up DB, also check rollback working properly

<!--
Write the need for the ticket.
-->