### PR TITLE
fix: [MySQL] meta records are created when conflicts occur in field creation

### DIFF
--- a/src/api/controllers/collections.ts
+++ b/src/api/controllers/collections.ts
@@ -66,7 +66,6 @@ router.post(
 
       await tx.transaction.schema.createTable(req.body.collection, (table) => {
         table.increments();
-        table.timestamps(true, true);
         req.body.status && table.string('status').notNullable();
       });
 

--- a/src/api/controllers/fields.ts
+++ b/src/api/controllers/fields.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response } from 'express';
 import { Knex } from 'knex';
 import { Field } from '../../config/types.js';
-import { InvalidPayloadException } from '../../exceptions/invalidPayload.js';
+
 import { SchemaOverview } from '../database/overview.js';
 import { asyncHandler } from '../middleware/asyncHandler.js';
 import {
@@ -12,6 +12,7 @@ import { BaseTransaction } from '../repositories/base.js';
 import { CollectionsRepository } from '../repositories/collections.js';
 import { FieldsRepository } from '../repositories/fields.js';
 import { RelationsRepository } from '../repositories/relations.js';
+import { FieldsService, addColumnToTable } from '../services/fields.js';
 
 const router = express.Router();
 
@@ -38,17 +39,10 @@ router.post(
   '/fields',
   permissionsHandler([{ collection: 'superfast_fields', action: 'create' }]),
   asyncHandler(async (req: Request, res: Response) => {
-    const repository = new FieldsRepository();
+    const service = new FieldsService(new FieldsRepository());
+    const field = await service.createField(req.body);
 
-    await repository.transaction(async (tx) => {
-      const fieldId = await repository.transacting(tx).create(req.body);
-      const field = await repository.transacting(tx).readOne(fieldId);
-      await tx.transaction.schema.alterTable(field.collection, (table) => {
-        addColumnToTable(field, table);
-      });
-
-      res.json({ field });
-    });
+    res.json({ field });
   })
 );
 
@@ -229,53 +223,6 @@ const deleteField = async (
     collection,
     field,
   });
-};
-
-const addColumnToTable = (field: Field, table: Knex.CreateTableBuilder, alter: boolean = false) => {
-  let column = null;
-
-  switch (field.interface) {
-    case 'input':
-      column = table.string(field.field, 255);
-      break;
-    case 'selectDropdown':
-      column = table.string(field.field, 255).defaultTo('');
-      break;
-    case 'inputMultiline':
-    case 'inputRichTextMd':
-      column = table.text(field.field);
-      break;
-    case 'boolean': {
-      const value = field.options ? JSON.parse(field.options) : null;
-      column = table.boolean(field.field).defaultTo(value?.defaultValue || false);
-      break;
-    }
-    case 'dateTime':
-      column = table.dateTime(field.field);
-      break;
-    case 'fileImage':
-      column = table
-        .integer(field.field)
-        .unsigned()
-        .index()
-        .references('id')
-        .inTable('superfast_files');
-      break;
-    case 'listOneToMany':
-      // noop
-      break;
-    case 'selectDropdownManyToOne':
-      column = table.integer(field.field).unsigned().index();
-      break;
-    default:
-      throw new InvalidPayloadException('unexpected_field_type_specified');
-  }
-
-  if (column && alter) {
-    column.alter();
-  }
-
-  return column;
 };
 
 export const fields = router;

--- a/src/api/database/seeds/dev.ts
+++ b/src/api/database/seeds/dev.ts
@@ -293,7 +293,6 @@ const createCollectionTables = async (database: Knex): Promise<void> => {
     table.string('body', 255);
     table.string('author', 255);
     table.string('status', 255);
-    table.timestamps(true, true);
   });
 
   await database.schema.createTable('Company', (table) => {
@@ -301,7 +300,6 @@ const createCollectionTables = async (database: Knex): Promise<void> => {
     table.string('name', 255);
     table.string('email', 255);
     table.string('address', 255);
-    table.timestamps(true, true);
   });
 
   Output.info('Adding collection data...');

--- a/src/api/services/fields.ts
+++ b/src/api/services/fields.ts
@@ -1,0 +1,81 @@
+import { Knex } from 'knex';
+import { Field } from '../../config/types.js';
+import { InvalidPayloadException } from '../../exceptions/invalidPayload.js';
+import { FieldsRepository } from '../repositories/fields.js';
+
+export class FieldsService {
+  repository: FieldsRepository;
+
+  constructor(repository: FieldsRepository) {
+    this.repository = repository;
+  }
+
+  /**
+   * Creates a new field in the database and adds a corresponding column to the collection's table.
+   * @param data
+   * @returns
+   */
+  async createField(data: Omit<Field, 'id'>): Promise<Field> {
+    const field = await this.repository.transaction(async (tx) => {
+      const fieldId = await this.repository.transacting(tx).create(data);
+      const field = await this.repository.transacting(tx).readOne(fieldId);
+      await tx.transaction.schema.alterTable(field.collection, (table) => {
+        addColumnToTable(field, table);
+      });
+      return field;
+    });
+
+    return field;
+  }
+}
+
+export const addColumnToTable = (
+  field: { interface: string; field: string; options: string | null },
+  table: Knex.CreateTableBuilder,
+  alter: boolean = false
+) => {
+  let column = null;
+
+  switch (field.interface) {
+    case 'input':
+      column = table.string(field.field, 255);
+      break;
+    case 'selectDropdown':
+      column = table.string(field.field, 255).defaultTo('');
+      break;
+    case 'inputMultiline':
+    case 'inputRichTextMd':
+      column = table.text(field.field);
+      break;
+    case 'boolean': {
+      const value = field.options ? JSON.parse(field.options) : null;
+      column = table.boolean(field.field).defaultTo(value?.defaultValue || false);
+      break;
+    }
+    case 'dateTime':
+      column = table.dateTime(field.field);
+      break;
+    case 'fileImage':
+      column = table
+        .integer(field.field)
+        .unsigned()
+        .index()
+        .references('id')
+        .inTable('superfast_files');
+      break;
+    case 'listOneToMany':
+      // noop
+      break;
+    case 'selectDropdownManyToOne':
+      column = table.integer(field.field).unsigned().index();
+      break;
+    default:
+      throw new InvalidPayloadException('unexpected_field_type_specified');
+  }
+
+  if (column && alter) {
+    column.alter();
+  }
+
+  return column;
+};

--- a/test/api/services/fields.test.ts
+++ b/test/api/services/fields.test.ts
@@ -80,8 +80,8 @@ describe('Field', () => {
 
         const field = {
           ...data,
-          field: 'created_at',
-          label: 'created_at',
+          field: 'id',
+          label: 'id',
         } as Omit<Field, 'id'>;
 
         const result = service.createField(field);
@@ -90,10 +90,10 @@ describe('Field', () => {
         // meta data should not be duplicated.
         const fetchFields = await repository.read({
           collection: 'collection_formula_one_constructors',
-          field: 'created_at',
+          field: 'id',
         });
 
-        expect(fetchFields).toHaveLength(0);
+        expect(fetchFields).toHaveLength(1);
       }
     );
   });

--- a/test/api/services/fields.test.ts
+++ b/test/api/services/fields.test.ts
@@ -1,0 +1,100 @@
+import knex, { Knex } from 'knex';
+import { FieldsRepository } from '../../../src/api/repositories/fields.js';
+import { FieldsService } from '../../../src/api/services/fields.js';
+import { Field } from '../../../src/config/types.js';
+import { config } from '../../config.js';
+import { testDatabases } from '../../utilities/testDatabases.js';
+
+describe('Field', () => {
+  const tableName = 'superfast_fields';
+  const databases = new Map<string, Knex>();
+
+  const data = {
+    collection: 'collection_formula_one_constructors',
+    interface: 'input',
+    required: false,
+    readonly: false,
+    hidden: false,
+  };
+
+  beforeAll(async () => {
+    for (const database of testDatabases) {
+      databases.set(database, knex(config.knexConfig[database]!));
+    }
+  });
+
+  afterAll(async () => {
+    for (const [_, connection] of databases) {
+      await connection.destroy();
+    }
+  });
+
+  describe('Create', () => {
+    it.each(testDatabases)('%s - should create', async (database) => {
+      const connection = databases.get(database)!;
+      const repository = new FieldsRepository(tableName, { knex: connection });
+      const service = new FieldsService(repository);
+
+      const field = {
+        ...data,
+        field: 'team_name',
+        label: 'Team Name',
+      } as Omit<Field, 'id'>;
+
+      const result = await service.createField(field);
+      expect(result).toBeTruthy();
+    });
+
+    it.each(testDatabases)('%s - should throw on duplication column error', async (database) => {
+      const connection = databases.get(database)!;
+      const repository = new FieldsRepository(tableName, { knex: connection });
+      const service = new FieldsService(repository);
+
+      const field = {
+        ...data,
+        field: 'point',
+        label: 'Point',
+      } as Omit<Field, 'id'>;
+
+      const fieldSuccess = await service.createField(field);
+      expect(fieldSuccess).toBeTruthy();
+
+      const fieldFail = service.createField(field);
+      await expect(fieldFail).rejects.toThrow();
+
+      // meta data should not be created
+      const fetchFields = await repository.read({
+        collection: 'collection_formula_one_constructors',
+        field: 'point',
+      });
+
+      expect(fetchFields).toHaveLength(1);
+    });
+
+    it.each(testDatabases)(
+      '%s - should throw on duplication system column error',
+      async (database) => {
+        const connection = databases.get(database)!;
+        const repository = new FieldsRepository(tableName, { knex: connection });
+        const service = new FieldsService(repository);
+
+        const field = {
+          ...data,
+          field: 'created_at',
+          label: 'created_at',
+        } as Omit<Field, 'id'>;
+
+        const result = service.createField(field);
+        await expect(result).rejects.toThrow();
+
+        // meta data should not be duplicated.
+        const fetchFields = await repository.read({
+          collection: 'collection_formula_one_constructors',
+          field: 'created_at',
+        });
+
+        expect(fetchFields).toHaveLength(0);
+      }
+    );
+  });
+});

--- a/test/setups/seeds/02_superfast_roles.ts
+++ b/test/setups/seeds/02_superfast_roles.ts
@@ -2,6 +2,6 @@ import { Knex } from 'knex';
 
 export const seed = async (knex: Knex): Promise<void> => {
   return await knex('superfast_roles').insert([
-    { id: 1, name: 'Administrator', description: 'Administrator', admin_access: true },
+    { name: 'Administrator', description: 'Administrator', admin_access: true },
   ]);
 };

--- a/test/setups/seeds/03_superfast_collections.ts
+++ b/test/setups/seeds/03_superfast_collections.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+export const seed = async (knex: Knex): Promise<void> => {
+  await knex('superfast_collections').insert([
+    {
+      id: 1,
+      collection: 'collection_formula_one_constructors',
+      singleton: false,
+      hidden: false,
+    },
+  ]);
+
+  await knex.schema.createTable('collection_formula_one_constructors', (table) => {
+    table.increments();
+    table.timestamps(true, true);
+  });
+};

--- a/test/setups/seeds/03_superfast_collections.ts
+++ b/test/setups/seeds/03_superfast_collections.ts
@@ -9,8 +9,16 @@ export const seed = async (knex: Knex): Promise<void> => {
     },
   ]);
 
+  await knex('superfast_fields').insert([
+    {
+      collection: 'collection_formula_one_constructors',
+      field: 'id',
+      label: 'id',
+      interface: 'input',
+    },
+  ]);
+
   await knex.schema.createTable('collection_formula_one_constructors', (table) => {
     table.increments();
-    table.timestamps(true, true);
   });
 };

--- a/test/setups/seeds/03_superfast_collections.ts
+++ b/test/setups/seeds/03_superfast_collections.ts
@@ -3,7 +3,6 @@ import { Knex } from 'knex';
 export const seed = async (knex: Knex): Promise<void> => {
   await knex('superfast_collections').insert([
     {
-      id: 1,
       collection: 'collection_formula_one_constructors',
       singleton: false,
       hidden: false,

--- a/test/setups/teardown.ts
+++ b/test/setups/teardown.ts
@@ -18,6 +18,7 @@ export default async function teardown(
     const database = knex(knexConfig);
 
     await database.migrate.rollback(knexConfig.migrations, true);
+    await database.schema.dropTableIfExists('collection_formula_one_constructors');
 
     if (testDatabase === 'sqlite3') {
       unlinkSync('test.db');


### PR DESCRIPTION
## What?
### Problem
Unexpected error when created_at (or updated_at) is specified in content type registration.
In addition, only MySQL has added created_at to the meta field.

Results are as follows.
- SQLite3 -> Error
- PostgreSQL -> Error
- MySQL, Maria -> Error, added to the meta fields.

### Solution
Remove timestamps from collection tables.
also, This makes sense for ease of migration from existing CMS.

<!--
Write a brief description of your commitments.
-->

## Why?
An error occurred here.
https://github.com/superfastcms/superfast/pull/844/files#diff-7d93df158fea591aba11cf5fa5d846804840ae4be0314bfdaeca63e9ec8de8f8R22-R24

Registration to meta field succeeds, but duplicate error occurs in the ALTER_TABLE.

MySQL's behavior is because of implicit commit.
https://github.com/knex/knex/issues/3452#issuecomment-534952063

> Apparently in MySQL creating a table causes an implicit commit https://dev.mysql.com/doc/refman/5.6/en/implicit-commit.html

<!--
Write the need for the ticket.
-->

## Notes
- Move logic from the controller to the service layer

<!--
Write commitment details.
-->
