### PR TITLE
refactor: remove references to `config/types` from repository layer

### DIFF
--- a/src/api/database/schemas.ts
+++ b/src/api/database/schemas.ts
@@ -12,7 +12,7 @@ export type Collection = {
   archive_value: string | null;
 } & PrimaryKey;
 
-export type Field = {
+export type FieldSchema = {
   collection: string;
   field: string;
   label: string;

--- a/src/api/repositories/collections.ts
+++ b/src/api/repositories/collections.ts
@@ -2,6 +2,7 @@ import { Collection } from '../../config/types.js';
 import { RecordNotUniqueException } from '../../exceptions/database/recordNotUnique.js';
 import { AbstractRepositoryOptions, BaseRepository, BaseTransaction } from './base.js';
 
+// TODO: Repository layer concerns allows only schema. see: ./fields.ts
 export class CollectionsRepository extends BaseRepository<Collection> {
   constructor(collection: string = 'superfast_collections', options?: AbstractRepositoryOptions) {
     super(collection, options);

--- a/src/api/repositories/fields.ts
+++ b/src/api/repositories/fields.ts
@@ -1,8 +1,8 @@
-import { Field } from '../../config/types.js';
 import { RecordNotUniqueException } from '../../exceptions/database/recordNotUnique.js';
+import { FieldSchema } from '../database/schemas.js';
 import { AbstractRepositoryOptions, BaseRepository, BaseTransaction } from './base.js';
 
-export class FieldsRepository extends BaseRepository<Field> {
+export class FieldsRepository extends BaseRepository<FieldSchema> {
   constructor(collection: string = 'superfast_fields', options?: AbstractRepositoryOptions) {
     super(collection, options);
   }
@@ -22,11 +22,11 @@ export class FieldsRepository extends BaseRepository<Field> {
    * @param data
    * @returns
    */
-  read(data: Partial<Field> = {}): Promise<Field[]> {
+  read(data: Partial<FieldSchema> = {}): Promise<FieldSchema[]> {
     return this.queryBuilder.where(data).orderBy('sort', 'asc', 'last').orderBy('sort', 'asc');
   }
 
-  async create(item: Omit<Field, 'id'>): Promise<number> {
+  async create(item: Omit<FieldSchema, 'id'>): Promise<number> {
     await this.checkUniqueField(item.collection, item.field);
     return super.create(item);
   }

--- a/src/api/repositories/files.ts
+++ b/src/api/repositories/files.ts
@@ -1,6 +1,7 @@
 import { File } from '../../config/types.js';
 import { AbstractRepositoryOptions, BaseRepository, BaseTransaction } from './base.js';
 
+// TODO: Repository layer concerns allows only schema. see: ./fields.ts
 export class FilesRepository extends BaseRepository<File> {
   constructor(collection: string = 'superfast_files', options?: AbstractRepositoryOptions) {
     super(collection, options);

--- a/src/api/repositories/permissions.ts
+++ b/src/api/repositories/permissions.ts
@@ -1,6 +1,7 @@
 import { Permission } from '../../config/types.js';
 import { AbstractRepositoryOptions, BaseRepository, BaseTransaction } from './base.js';
 
+// TODO: Repository layer concerns allows only schema. see: ./fields.ts
 export class PermissionsRepository extends BaseRepository<Permission> {
   constructor(collection: string = 'superfast_permissions', options?: AbstractRepositoryOptions) {
     super(collection, options);

--- a/src/api/repositories/projectSettings.ts
+++ b/src/api/repositories/projectSettings.ts
@@ -1,6 +1,7 @@
 import { ProjectSetting } from '../../config/types.js';
 import { AbstractRepositoryOptions, BaseRepository, BaseTransaction } from './base.js';
 
+// TODO: Repository layer concerns allows only schema. see: ./fields.ts
 export class ProjectSettingsRepository extends BaseRepository<ProjectSetting> {
   constructor(
     collection: string = 'superfast_project_settings',

--- a/src/api/repositories/relations.ts
+++ b/src/api/repositories/relations.ts
@@ -1,6 +1,7 @@
 import { Relation } from '../../config/types.js';
 import { AbstractRepositoryOptions, BaseRepository, BaseTransaction } from './base.js';
 
+// TODO: Repository layer concerns allows only schema. see: ./fields.ts
 export class RelationsRepository extends BaseRepository<Relation> {
   constructor(collection: string = 'superfast_relations', options?: AbstractRepositoryOptions) {
     super(collection, options);

--- a/src/api/repositories/roles.ts
+++ b/src/api/repositories/roles.ts
@@ -1,6 +1,7 @@
 import { Role } from '../../config/types.js';
 import { AbstractRepositoryOptions, BaseRepository, BaseTransaction } from './base.js';
 
+// TODO: Repository layer concerns allows only schema. see: ./fields.ts
 export class RolesRepository extends BaseRepository<Role> {
   constructor(collection: string = 'superfast_roles', options?: AbstractRepositoryOptions) {
     super(collection, options);

--- a/src/api/repositories/users.ts
+++ b/src/api/repositories/users.ts
@@ -4,6 +4,7 @@ import { RecordNotUniqueException } from '../../exceptions/database/recordNotUni
 import { InvalidCredentialsException } from '../../exceptions/invalidCredentials.js';
 import { AbstractRepositoryOptions, BaseRepository, BaseTransaction } from './base.js';
 
+// TODO: Repository layer concerns allows only schema. see: ./fields.ts
 export class UsersRepository extends BaseRepository<User> {
   constructor(collection: string = 'superfast_users', options?: AbstractRepositoryOptions) {
     super(collection, options);

--- a/src/api/services/fields.ts
+++ b/src/api/services/fields.ts
@@ -22,7 +22,7 @@ export class FieldsService {
       await tx.transaction.schema.alterTable(field.collection, (table) => {
         addColumnToTable(field, table);
       });
-      return field;
+      return field as Field;
     });
 
     return field;
@@ -30,7 +30,7 @@ export class FieldsService {
 }
 
 export const addColumnToTable = (
-  field: { interface: string; field: string; options: string | null },
+  field: { interface: string | null; field: string; options: string | null },
   table: Knex.CreateTableBuilder,
   alter: boolean = false
 ) => {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,6 +1,6 @@
 import {
   Collection as CollectionSchema,
-  Field as FieldSchema,
+  FieldSchema,
   File as FileSchema,
   Permission as PermissionSchema,
   ProjectSetting as ProjectSettingSchema,


### PR DESCRIPTION
## What?
Eliminate references to config/types from the repository.

<!--
Write a brief description of your commitments.
-->

## Why?
Repository should only be concerned with the schema.

<!--
Write the need for the ticket.
-->

## How?
Remove reference to `config/types`, handle `database/schemas` types.

<!--
For user functionality additions, write the operating procedures.
For development modifications, write the configuration procedure.
For bug fixes, write the reproduction procedure.
-->