### PR TITLE
Revert "build(deps): bump pino-http from 8.3.3 to 8.4.0"

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8652,9 +8652,9 @@ pino-abstract-transport@^1.0.0, pino-abstract-transport@v1.0.0:
     split2 "^4.0.0"
 
 pino-http@^8.3.3:
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/pino-http/-/pino-http-8.4.0.tgz#ebfd601f7244d7bd9ead578843025505da4e3f56"
-  integrity sha512-9I1eRLxsujQJwLQTrHBU0wDlwnry2HzV2TlDwAsmZ9nT3Y2NQBLrz+DYp73L4i11vl/eudnFT8Eg0Kp62tMwEw==
+  version "8.3.3"
+  resolved "https://registry.npmjs.org/pino-http/-/pino-http-8.3.3.tgz"
+  integrity sha512-p4umsNIXXVu95HD2C8wie/vXH7db5iGRpc+yj1/ZQ3sRtTQLXNjoS6Be5+eI+rQbqCRxen/7k/KSN+qiZubGDw==
   dependencies:
     get-caller-file "^2.0.5"
     pino "^8.0.0"


### PR DESCRIPTION
Reverts superfastcms/superfast#867

```
TypeError
Cannot read properties of undefined (reading 'stringifySym')
```