### PR TITLE
refactor: add AND / OR conditions to readByQuery

### DIFF
--- a/src/api/controllers/collections.ts
+++ b/src/api/controllers/collections.ts
@@ -115,7 +115,7 @@ router.delete(
       });
 
       const permissions = await permissionsService.readMany({
-        filter: { collection: collection.collection },
+        filter: { collection: { _eq: collection.collection } },
       });
       const ids = permissions.map((permission) => permission.id);
       await permissionsService.deleteMany(ids);

--- a/src/api/controllers/roles.ts
+++ b/src/api/controllers/roles.ts
@@ -79,7 +79,9 @@ router.get(
     const id = Number(req.params.id);
 
     const permissionsService = new PermissionsService({ schema: req.schema });
-    const permissions = await permissionsService.readMany({ filter: { role_id: id } });
+    const permissions = await permissionsService.readMany({
+      filter: { role_id: { _eq: id } },
+    });
 
     res.json({ permissions });
   })

--- a/src/api/database/types.ts
+++ b/src/api/database/types.ts
@@ -1,0 +1,24 @@
+export type Query = {
+  filter?: Filter | null;
+};
+
+export type Filter = LogicalFilter | FieldFilter;
+
+export type LogicalFilter = LogicalFilterOr | LogicalFilterAnd;
+
+export type LogicalFilterOr = {
+  _or: FieldFilter[];
+};
+
+export type LogicalFilterAnd = {
+  _and: FieldFilter[];
+};
+
+export type FieldFilter = {
+  [field: string]: FieldFilterOperator;
+};
+
+export type FieldFilterOperator = {
+  _eq?: string | number | boolean;
+  _gt?: string | number | boolean;
+};

--- a/src/api/middleware/permissionsHandler.ts
+++ b/src/api/middleware/permissionsHandler.ts
@@ -16,7 +16,7 @@ export const collectionPermissionsHandler =
       });
 
       const userPermissions = await permissionsService.readMany({
-        filter: { role_id: Number(req.roleId) },
+        filter: { role_id: { _eq: Number(req.roleId) } },
       });
 
       const hasPermission = userPermissions.some(
@@ -45,7 +45,7 @@ export const permissionsHandler =
       });
 
       const userPermissions = await permissionsService.readMany({
-        filter: { role_id: Number(req.roleId) },
+        filter: { role_id: { _eq: Number(req.roleId) } },
       });
 
       const hasPermission = permissions.every((permission) =>

--- a/src/api/repositories/users.ts
+++ b/src/api/repositories/users.ts
@@ -80,15 +80,6 @@ export class UsersRepository extends BaseRepository<User> {
     return this.toAuthUser(user);
   }
 
-  readResetPasswordToken(token: string): Promise<User> {
-    return this.queryBuilder
-      .select('u.*')
-      .from('superfast_users AS u')
-      .where('u.reset_password_token', token)
-      .where('u.reset_password_expiration', '>', Date.now())
-      .first();
-  }
-
   private toAuthUser(user: {
     id: number;
     role_id: number;

--- a/src/api/services/base.ts
+++ b/src/api/services/base.ts
@@ -9,10 +9,7 @@ import { readByQuery } from '../database/operations/readByQuery.js';
 import { updateOne } from '../database/operations/updateOne.js';
 import { SchemaOverview } from '../database/overview.js';
 import { PrimaryKey, TypeWithId } from '../database/schemas.js';
-
-type Query = {
-  filter?: Record<string, any>;
-};
+import { Query } from '../database/types.js';
 
 type AbstractService<T extends TypeWithId = any> = {
   readOne(key: PrimaryKey): Promise<T>;

--- a/src/api/services/roles.ts
+++ b/src/api/services/roles.ts
@@ -22,7 +22,9 @@ export class RolesService extends BaseService<Role> {
 
     const role = await this.readOne(key);
     if (role.admin_access) {
-      const roles = await this.readMany({ filter: { admin_access: true } });
+      const roles = await this.readMany({
+        filter: { admin_access: { _eq: true } },
+      });
       if (roles.length === 1) {
         throw new UnprocessableEntityException('can_not_delete_last_admin_role');
       }
@@ -38,7 +40,7 @@ export class RolesService extends BaseService<Role> {
       });
 
       const permissions = await permissionsService.readMany({
-        filter: { role_id: key },
+        filter: { role_id: { _eq: key } },
       });
 
       const keys = permissions.map((permission) => permission.id);

--- a/src/api/services/users.ts
+++ b/src/api/services/users.ts
@@ -19,12 +19,13 @@ export class UsersService extends BaseService<User> {
    * @returns auth user or null
    */
   async readMe(params: { primaryKey?: PrimaryKey; apiKey?: string }): Promise<Me | null> {
-    if (!params.primaryKey && !params.apiKey) return null;
+    const { primaryKey, apiKey } = params;
+    if (!primaryKey && !apiKey) return null;
 
-    let filter = params.primaryKey ? { id: params.primaryKey } : { api_key: params.apiKey };
-    const user = await this.readMany({ filter: filter }).then((users) =>
-      users.length > 0 ? users[0] : null
-    );
+    const user = await this.readMany({
+      filter: primaryKey ? { id: { _eq: primaryKey } } : { api_key: { _eq: apiKey } },
+    }).then((users) => (users.length > 0 ? users[0] : null));
+
     if (!user || !user.role_id) return null;
 
     const rolesService = new RolesService({ schema: this.schema });

--- a/src/exceptions/invalidQuery.ts
+++ b/src/exceptions/invalidQuery.ts
@@ -1,0 +1,7 @@
+import { BaseException } from './base.js';
+
+export class InvalidQueryException extends BaseException {
+  constructor(public extensions?: Record<string, any>) {
+    super(400, 'invalid_query', extensions);
+  }
+}

--- a/src/lang/translations/en/translation.json
+++ b/src/lang/translations/en/translation.json
@@ -183,7 +183,8 @@
     "invalid_secret_key": "Invalid secret key.",
     "file_does_not_exist": "File does not exist.",
     "token_expired": "Token expired.",
-    "invalid_token": "Invalid token"
+    "invalid_token": "Invalid token.",
+    "invalid_query": "Invalid query."
   },
   "yup": {
     "mixed": {

--- a/src/lang/translations/ja/translation.json
+++ b/src/lang/translations/ja/translation.json
@@ -183,7 +183,8 @@
     "invalid_secret_key": "シークレットキーが有効ではありません。",
     "file_does_not_exist": "ファイルが存在しません。",
     "token_expired": "トークンの有効期限が切れました。",
-    "invalid_token": "無効なトークンです。"
+    "invalid_token": "無効なトークンです。",
+    "invalid_query": "無効なクエリーです。"
   },
   "yup": {
     "mixed": {

--- a/test/api/database/operations/readByQuery.test.ts
+++ b/test/api/database/operations/readByQuery.test.ts
@@ -1,0 +1,157 @@
+import knex, { Knex } from 'knex';
+import { describe } from 'node:test';
+import { readByQuery } from '../../../../src/api/database/operations/readByQuery.js';
+import { config } from '../../../config.js';
+import { testDatabases } from '../../../utilities/testDatabases.js';
+
+describe('Read By Query', () => {
+  const tableName = 'collection_f1_grand_prix_races';
+  const databases = new Map<string, Knex>();
+  type CollectionType = {
+    year: string;
+    round: string;
+    circuit: string;
+  };
+
+  beforeAll(async () => {
+    for (const database of testDatabases) {
+      const connection = knex(config.knexConfig[database]!);
+      databases.set(database, connection);
+      await insertRecords(connection);
+    }
+  });
+
+  const insertRecords = async (connection: Knex) => {
+    await connection(tableName).insert([
+      {
+        year: '2021',
+        round: '1',
+        circuit: 'Bahrain',
+      },
+      {
+        year: '2022',
+        round: '1',
+        circuit: 'Bahrain',
+      },
+      {
+        year: '2023',
+        round: '1',
+        circuit: 'Bahrain',
+      },
+      {
+        year: '2023',
+        round: '2',
+        circuit: 'Saudi Arabia',
+      },
+    ]);
+  };
+
+  afterAll(async () => {
+    for (const [_, connection] of databases) {
+      await connection(tableName).del();
+      await connection.destroy();
+    }
+  });
+
+  describe('Get', () => {
+    it.each(testDatabases)('%s - should get all records', async (database) => {
+      const connection = databases.get(database)!;
+      const results = await readByQuery({ database: connection, collection: tableName });
+
+      expect(results).toHaveLength(4);
+    });
+
+    // circuit = "Bahrain"
+    it.each(testDatabases)('%s - should get filtered records', async (database) => {
+      const connection = databases.get(database)!;
+
+      const results = await readByQuery<CollectionType>({
+        database: connection,
+        collection: tableName,
+        filter: { circuit: { _eq: 'Bahrain' } },
+      });
+      expect(results).toHaveLength(3);
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ circuit: 'Bahrain', year: '2021' }),
+          expect.objectContaining({ circuit: 'Bahrain', year: '2022' }),
+          expect.objectContaining({ circuit: 'Bahrain', year: '2023' }),
+        ])
+      );
+    });
+
+    // circuit = "Bahrain" AND year > "2021"
+    it.each(testDatabases)(
+      '%s - should get records filtered by _and condition',
+      async (database) => {
+        const connection = databases.get(database)!;
+
+        const results = await readByQuery<CollectionType>({
+          database: connection,
+          collection: tableName,
+          filter: {
+            _and: [{ circuit: { _eq: 'Bahrain' } }, { year: { _gt: '2021' } }],
+          },
+        });
+        expect(results).toHaveLength(2);
+        expect(results).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ circuit: 'Bahrain', year: '2022' }),
+            expect.objectContaining({ circuit: 'Bahrain', year: '2023' }),
+          ])
+        );
+      }
+    );
+
+    // circuit = "Bahrain" OR circuit = "Saudi Arabia"
+    it.each(testDatabases)(
+      '%s - should get records filtered by _or condition',
+      async (database) => {
+        const connection = databases.get(database)!;
+
+        const results = await readByQuery<CollectionType>({
+          database: connection,
+          collection: tableName,
+          filter: {
+            _or: [{ circuit: { _eq: 'Bahrain' } }, { circuit: { _eq: 'Saudi Arabia' } }],
+          },
+        });
+        expect(results).toHaveLength(4);
+        expect(results).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ circuit: 'Bahrain', year: '2021' }),
+            expect.objectContaining({ circuit: 'Bahrain', year: '2022' }),
+            expect.objectContaining({ circuit: 'Bahrain', year: '2023' }),
+            expect.objectContaining({ circuit: 'Saudi Arabia', year: '2023' }),
+          ])
+        );
+      }
+    );
+
+    it.each(testDatabases)('%s - should throw invalid query', async (database) => {
+      const connection = databases.get(database)!;
+
+      const results = readByQuery<CollectionType>({
+        database: connection,
+        collection: tableName,
+        filter: { circuit: { _eq: undefined } },
+      });
+
+      const results1 = readByQuery<CollectionType>({
+        database: connection,
+        collection: tableName,
+        filter: { _and: [{ circuit: { _eq: 'Bahrain' } }, { circuit: { _eq: undefined } }] },
+      });
+
+      const results2 = readByQuery<CollectionType>({
+        database: connection,
+        collection: tableName,
+        filter: { _or: [{ circuit: { _gt: undefined } }, { circuit: { _eq: 'Bahrain' } }] },
+      });
+
+      expect(results).rejects.toThrow();
+      expect(results1).rejects.toThrow();
+      expect(results2).rejects.toThrow();
+    });
+  });
+});

--- a/test/api/database/overview.test.ts
+++ b/test/api/database/overview.test.ts
@@ -73,6 +73,7 @@ describe('Schema Overview', () => {
         fields: {
           id: { alias: false, field: 'id' },
           circuit: { alias: false, field: 'circuit' },
+          round: { alias: false, field: 'round' },
           year: { alias: false, field: 'year' },
           created_at: { alias: false, field: 'created_at' },
           updated_at: { alias: false, field: 'updated_at' },

--- a/test/api/repositories/contents.test.ts
+++ b/test/api/repositories/contents.test.ts
@@ -10,12 +10,26 @@ describe('Contents', () => {
 
   beforeAll(async () => {
     for (const database of testDatabases) {
-      databases.set(database, knex(config.knexConfig[database]!));
+      const connection = knex(config.knexConfig[database]!);
+      databases.set(database, connection);
+      await insertRecords(connection);
     }
   });
 
+  const insertRecords = async (connection: Knex) => {
+    await connection(tableName).insert([
+      {
+        year: '2022',
+        round: '1',
+        circuit: 'Bahrain',
+        updated_at: '2022-01-01 00:00:00',
+      },
+    ]);
+  };
+
   afterAll(async () => {
     for (const [_, connection] of databases) {
+      await connection(tableName).del();
       await connection.destroy();
     }
   });
@@ -25,7 +39,7 @@ describe('Contents', () => {
       const connection = databases.get(database)!;
 
       const repository = new ContentsRepository(tableName, { knex: connection });
-      const data = await repository.create({ year: 2023, round: 1, circuit: 'Bahrain' });
+      const data = await repository.create({ year: '2023', round: '1', circuit: 'Bahrain' });
 
       expect(data).toBeTruthy();
     });
@@ -36,7 +50,7 @@ describe('Contents', () => {
       const connection = databases.get(database)!;
 
       const repository = new ContentsRepository(tableName, { knex: connection });
-      const data = await repository.read({ year: 2022, circuit: 'Bahrain' });
+      const data = await repository.read({ year: '2022', circuit: 'Bahrain' });
       const id = data[0].id;
 
       const result = await repository.update(id, { circuit: 'Bahrain International Circuit' });

--- a/test/api/repositories/contents.test.ts
+++ b/test/api/repositories/contents.test.ts
@@ -25,7 +25,7 @@ describe('Contents', () => {
       const connection = databases.get(database)!;
 
       const repository = new ContentsRepository(tableName, { knex: connection });
-      const data = await repository.create({ year: 2023, circuit: 'Bahrain' });
+      const data = await repository.create({ year: 2023, round: 1, circuit: 'Bahrain' });
 
       expect(data).toBeTruthy();
     });

--- a/test/setups/seeds/03_superfast_collections.ts
+++ b/test/setups/seeds/03_superfast_collections.ts
@@ -45,11 +45,4 @@ export const seed = async (database: Knex): Promise<void> => {
     table.string('round', 255);
     table.string('circuit', 255);
   });
-
-  await database(collectionName).insert([
-    {
-      year: 2022,
-      circuit: 'Bahrain',
-    },
-  ]);
 };

--- a/test/setups/seeds/03_superfast_collections.ts
+++ b/test/setups/seeds/03_superfast_collections.ts
@@ -20,6 +20,12 @@ export const seed = async (database: Knex): Promise<void> => {
     },
     {
       collection: collectionName,
+      field: 'round',
+      label: 'Round',
+      interface: 'input',
+    },
+    {
+      collection: collectionName,
       field: 'year',
       label: 'Year',
       interface: 'input',
@@ -36,6 +42,7 @@ export const seed = async (database: Knex): Promise<void> => {
     table.increments();
     table.timestamps(true, true);
     table.string('year', 255);
+    table.string('round', 255);
     table.string('circuit', 255);
   });
 


### PR DESCRIPTION
## What?
Add AND/OR conditions to readByQuery to reduce raw SQL execution.

<!--
Write a brief description of your commitments.
-->

## Why?
Not versatile, Not testable

<!--
Write the need for the ticket.
-->

## How?
Get all records
```
readMany()
```

Get filtered records
```
readMany({
  filter: { key: { _eq: value } }
})
```

Get records filtered by _and
```
readMany({
  filter: {
    _and: [{ key: { _eq: value } }, { key: { _gt: value } }]
  }
})
```

Get records filtered by _or
```
readMany({
  filter: {
    _or: [{ key: { _eq: value } }, { key: { _gt: value } }]
  }
})
```

<!--
For user functionality additions, write the operating procedures.
For development modifications, write the configuration procedure.
For bug fixes, write the reproduction procedure.
-->