### PR TITLE
fix: delete a field using a transaction added to the parameters

### DIFF
--- a/src/api/controllers/fields.ts
+++ b/src/api/controllers/fields.ts
@@ -84,11 +84,10 @@ router.delete(
   '/collections/:collectionId/fields/:id',
   permissionsHandler([{ collection: 'superfast_fields', action: 'delete' }]),
   asyncHandler(async (req: Request, res: Response) => {
-    const collectionId = Number(req.params.collectionId);
     const fieldId = Number(req.params.id);
 
     const service = new FieldsService({ schema: req.schema });
-    await service.deleteField(collectionId, fieldId);
+    await service.deleteField(fieldId);
 
     res.status(204).end();
   })

--- a/src/api/database/operations/readById.ts
+++ b/src/api/database/operations/readById.ts
@@ -21,7 +21,7 @@ export const readById = async <T>(args: Arguments): Promise<T> => {
     .select()
     .then((results) => results[0]);
 
-  if (overview) {
+  if (result && overview) {
     await applyTransformersToFields('read', result, overview, helpers);
   }
 

--- a/src/api/services/collections.ts
+++ b/src/api/services/collections.ts
@@ -95,7 +95,9 @@ export class CollectionsService extends BaseService<Collection> {
    */
   async deleteCollection(key: PrimaryKey): Promise<void> {
     await this.database.transaction(async (tx) => {
-      /////////////////////////// Delete Relation ///////////////////////////
+      // /////////////////////////////////////
+      // Delete Relation
+      // /////////////////////////////////////
       const collectionsService = new CollectionsService({ database: tx, schema: this.schema });
       const collection = await collectionsService.readOne(key);
 
@@ -129,7 +131,7 @@ export class CollectionsService extends BaseService<Collection> {
       });
 
       for (let relation of oneRelations) {
-        await fieldsService.executeFieldDelete(relation.many_collection, relation.many_field);
+        await fieldsService.executeFieldDelete(tx, relation.many_collection, relation.many_field);
       }
 
       // Delete one relation fields
@@ -138,7 +140,7 @@ export class CollectionsService extends BaseService<Collection> {
       });
 
       for (let relation of manyRelations) {
-        await fieldsService.executeFieldDelete(relation.one_collection, relation.one_field);
+        await fieldsService.executeFieldDelete(tx, relation.one_collection, relation.one_field);
       }
 
       // Delete relations
@@ -148,8 +150,9 @@ export class CollectionsService extends BaseService<Collection> {
 
       await relationsService.deleteMany(relationIds);
 
-      ///////////////////////// Delete Entity ///////////////////////////
-
+      // /////////////////////////////////////
+      // Delete Entity
+      // /////////////////////////////////////
       await tx.schema.dropTable(collection.collection);
     });
   }

--- a/src/api/services/fields.ts
+++ b/src/api/services/fields.ts
@@ -168,7 +168,7 @@ export class FieldsService extends BaseService<Field> {
       });
 
       for (let relation of oneRelations) {
-        await this.executeFieldDelete(relation.many_collection, relation.many_field);
+        await this.executeFieldDelete(tx, relation.many_collection, relation.many_field);
       }
 
       // Delete one relation fields
@@ -182,7 +182,7 @@ export class FieldsService extends BaseService<Field> {
       });
 
       for (let relation of manyRelations) {
-        await this.executeFieldDelete(relation.one_collection, relation.one_field);
+        await this.executeFieldDelete(tx, relation.one_collection, relation.one_field);
       }
 
       // Delete relations schema
@@ -193,9 +193,9 @@ export class FieldsService extends BaseService<Field> {
       await relationsService.deleteMany(relationIds);
 
       // /////////////////////////////////////
-      // Delete Entity
+      // Delete Field
       // /////////////////////////////////////
-      await this.executeFieldDelete(collection.collection, field.field);
+      await this.executeFieldDelete(tx, collection.collection, field.field);
     });
   }
 
@@ -205,7 +205,10 @@ export class FieldsService extends BaseService<Field> {
    * @param collection
    * @param field
    */
-  async executeFieldDelete(collection: string, field: string) {
+  async executeFieldDelete(tx: Knex.Transaction, collection: string, field: string) {
+    // /////////////////////////////////////
+    // Delete Entity
+    // /////////////////////////////////////
     const hasEntity = !this.schema.collections[collection].fields[field].alias;
     const existingRelation = this.schema.relations.find(
       (existingRelation) =>
@@ -214,21 +217,30 @@ export class FieldsService extends BaseService<Field> {
           existingRelation.relatedField === field)
     );
 
+    const service = new FieldsService({ database: tx, schema: this.schema });
+
     if (hasEntity) {
-      await this.database.schema.table(collection, (table) => {
+      await service.database.schema.table(collection, (table) => {
         // If the FK already exists in the DB, drop it first
         if (existingRelation !== undefined) table.dropForeign(field);
         table.dropColumn(field);
       });
     }
 
-    const fields = await this.readMany({
-      filter: {
-        _and: [{ collection: { _eq: collection } }, { field: { _eq: field } }],
-      },
-    });
-    const fieldIds = fields.map((field) => field.id);
-    await this.deleteMany(fieldIds);
+    // /////////////////////////////////////
+    // Delete Meta
+    // /////////////////////////////////////
+    const fieldIds = await service
+      .readMany({
+        filter: {
+          _and: [{ collection: { _eq: collection } }, { field: { _eq: field } }],
+        },
+      })
+      .then((fields) => fields.map((field) => field.id));
+
+    if (fieldIds.length > 0) {
+      await service.deleteMany(fieldIds);
+    }
   }
 
   private async checkUniqueField(collection: string, field: string) {

--- a/test/api/services/collections.test.ts
+++ b/test/api/services/collections.test.ts
@@ -116,4 +116,22 @@ describe('Collection', () => {
       expect(result).rejects.toThrow();
     });
   });
+
+  describe('Delete', () => {
+    it.each(testDatabases)('%s - should delete', async (database) => {
+      const connection = databases.get(database)!;
+      const schema = await getSchemaOverview({ database: connection });
+      const service = new CollectionsService({ database: connection, schema });
+
+      const fetchedCollection = await service
+        .readMany({
+          filter: { collection: { _eq: data1.collection } },
+        })
+        .then((data) => data[0]);
+
+      await service.deleteCollection(fetchedCollection.id);
+      const data = await service.readOne(fetchedCollection.id);
+      expect(data).toBeUndefined();
+    });
+  });
 });

--- a/test/api/services/fields.test.ts
+++ b/test/api/services/fields.test.ts
@@ -132,17 +132,15 @@ describe('Field', () => {
       const schema = await getSchemaOverview({ database: connection });
       const service = new FieldsService({ database: connection, schema });
 
-      const field = {
-        ...fieldData,
-        field: 'base',
-        label: 'Base',
-      } as Omit<Field, 'id'>;
+      const field = await service
+        .readMany({
+          filter: { field: { _eq: 'team_name' } },
+        })
+        .then((data) => data[0]);
 
-      const createdField = await service.createField(field);
-      expect(createdField).toBeTruthy();
-
-      const result = await service.deleteField(createdField.id);
-      expect(result).toBeTruthy();
+      await service.deleteField(field.id);
+      const data = await service.readOne(field.id);
+      expect(data).toBeUndefined();
     });
   });
 });

--- a/test/api/services/fields.test.ts
+++ b/test/api/services/fields.test.ts
@@ -125,4 +125,24 @@ describe('Field', () => {
       }
     );
   });
+
+  describe('Delete', () => {
+    it.each(testDatabases)('%s - should delete', async (database) => {
+      const connection = databases.get(database)!;
+      const schema = await getSchemaOverview({ database: connection });
+      const service = new FieldsService({ database: connection, schema });
+
+      const field = {
+        ...fieldData,
+        field: 'base',
+        label: 'Base',
+      } as Omit<Field, 'id'>;
+
+      const createdField = await service.createField(field);
+      expect(createdField).toBeTruthy();
+
+      const result = await service.deleteField(createdField.id);
+      expect(result).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
## What?
Delete a field using a transaction added to the parameters.

<!--
Write a brief description of your commitments.
-->

## Why?
Error on field deletion.

<!--
Write the need for the ticket.
-->

## How?
Add a transaction to the parameters of `executeFieldDelete`.
Resolve the error that occurs when passing a non-existent id to `readById`.

<!--
For user functionality additions, write the operating procedures.
For development modifications, write the configuration procedure.
For bug fixes, write the reproduction procedure.
-->
