### PR TITLE
fix: fixed to call schema overview after express startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## ⭐ What is Superfast
 
-Open source Headless CMS built with React, Node.js, RDB. We are planning an importer to make the transition from a legacy CMS.
+This open-source Headless CMS uses React, Node.js, and RDB. Just model in the GUI, register data – retrieving via API is seamless! We're also developing an importer to smooth legacy CMS migration.
 
 ### Features
 
 - 📚 Support English / 日本語
 - 😻 Markdown can be used (with GitHub flavored markdown)
-- 🌒 Support light-mode/dark-mode
+- 🌒 Support light-mode / dark-mode
 - 📱 Responsive Design
 
 ## 📚 Usage & Documentation

--- a/src/api/router/apiRouter.ts
+++ b/src/api/router/apiRouter.ts
@@ -15,7 +15,6 @@ import { users } from '../controllers/users.js';
 import { authHandler } from '../middleware/authHandler.js';
 import { corsMiddleware } from '../middleware/cors.js';
 import { extractTokenHandler } from '../middleware/extractTokenHandler.js';
-import { schemaOverview } from '../middleware/schemaOverview.js';
 
 const router = express.Router();
 
@@ -27,8 +26,6 @@ router.use(cookieParser());
 router.use(express.json({ limit: env.REQ_LIMIT }));
 router.use(express.urlencoded({ limit: env.REQ_LIMIT, extended: true }));
 router.use(expressLogger);
-
-router.use(schemaOverview);
 
 router.use(extractTokenHandler);
 router.use(authHandler);

--- a/src/express/api.ts
+++ b/src/express/api.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import { Express } from 'express';
 import { assets } from '../api/controllers/assets.js';
 import { errorHandler } from '../api/middleware/errorHandler.js';
+import { schemaOverview } from '../api/middleware/schemaOverview.js';
 import { apiRouter } from '../api/router/apiRouter.js';
 import { env } from '../env.js';
 import { logger } from '../utilities/logger.js';
@@ -12,6 +13,7 @@ export const initApiServer = async (app: Express) => {
   const port = env.SERVER_PORT;
   const host = env.SERVER_HOST;
 
+  app.use(schemaOverview);
   app.use('/', assets);
   app.use('/api', apiRouter);
   app.use(errorHandler);

--- a/src/scripts/operations/chooseDatabase.ts
+++ b/src/scripts/operations/chooseDatabase.ts
@@ -3,8 +3,8 @@ import { DBClient } from '../../api/database/connection.js';
 import { Output } from '../../utilities/output.js';
 
 const drivers: Record<DBClient, string> = {
-  mysql: 'MySQL / MariaDB / Aurora',
-  pg: 'PostgreSQL / Redshift',
+  mysql: 'MySQL / MariaDB',
+  pg: 'PostgreSQL',
   sqlite3: 'SQLite',
 };
 


### PR DESCRIPTION
## What?
Fixed to call schema overview after express startup.

<!--
Write a brief description of your commitments.
-->

## Why?
Entry points for `/assets` and `/api` are placed, but only `/api` is called to get schema overview.

<!--
Write the need for the ticket.
-->

## How?
Move to `initApiServer`.

<!--
For user functionality additions, write the operating procedures.
For development modifications, write the configuration procedure.
For bug fixes, write the reproduction procedure.
-->