### PR TITLE
refactor: delete DTO used in layers deeper than the controller

### DIFF
--- a/src/api/controllers/collections.ts
+++ b/src/api/controllers/collections.ts
@@ -1,5 +1,4 @@
 import express, { Request, Response } from 'express';
-import { GetCollection, GetCollections } from '../../config/types.js';
 import { RecordNotFoundException } from '../../exceptions/database/recordNotFound.js';
 import { Query } from '../database/types.js';
 import { asyncHandler } from '../middleware/asyncHandler.js';
@@ -21,7 +20,7 @@ router.get(
     res.json({
       collection: {
         ...collection,
-      } as GetCollection,
+      },
     });
   })
 );
@@ -38,7 +37,7 @@ router.get(
     const service = new CollectionsService({ schema: req.schema });
     const collections = await service.readMany(query);
 
-    res.json({ collections } as GetCollections);
+    res.json({ collections });
   })
 );
 

--- a/src/api/controllers/fields.ts
+++ b/src/api/controllers/fields.ts
@@ -15,8 +15,15 @@ router.get(
     const service = new FieldsService({ schema: req.schema });
     const fields = await service.getFields(req.params.collection);
 
+    const fieldWithOptions = fields.map((field) => {
+      return {
+        ...field,
+        fieldOption: field.options ? JSON.parse(field.options) : null,
+      };
+    });
+
     res.json({
-      fields,
+      fields: fieldWithOptions,
     });
   })
 );

--- a/src/api/services/fields.ts
+++ b/src/api/services/fields.ts
@@ -1,5 +1,4 @@
 import { Knex } from 'knex';
-import { GetField } from '../../config/types.js';
 import { RecordNotUniqueException } from '../../exceptions/database/recordNotUnique.js';
 import { InvalidPayloadException } from '../../exceptions/invalidPayload.js';
 import { Field, PrimaryKey, Relation } from '../database/schemas.js';
@@ -19,7 +18,7 @@ export class FieldsService extends BaseService<Field> {
    * @param collection
    * @returns fields
    */
-  async getFields(collection: string): Promise<GetField[]> {
+  async getFields(collection: string): Promise<Field[]> {
     const fields = await this.readMany(
       {
         filter: { collection: { _eq: collection } },
@@ -29,15 +28,7 @@ export class FieldsService extends BaseService<Field> {
         { column: 'sort', order: 'asc' },
       ]
     );
-
-    const getFields = fields.map((field) => {
-      return {
-        ...field,
-        fieldOption: field.options ? JSON.parse(field.options) : null,
-      } as GetField;
-    });
-
-    return getFields;
+    return fields;
   }
 
   /**


### PR DESCRIPTION
## What?
Delete DTO used in layers deeper than the controller.

<!--
Write a brief description of your commitments.
-->

## Why?
Because it becomes tightly coupled when used in a layer deeper than the controller. 
DTO should be a converter that handles responses from backend.

<!--
Write the need for the ticket.
-->