### PR TITLE
refactor: sort order by name -> slug when importing from WordPress

### DIFF
--- a/src/api/services/importData.ts
+++ b/src/api/services/importData.ts
@@ -110,8 +110,8 @@ export class ImportDataService {
       {
         collection: 'category',
         collection_id: collectionKeys['category'],
-        field: 'slug',
-        label: 'Slug',
+        field: 'name',
+        label: 'Name',
         interface: 'input',
         readonly: false,
         required: false,
@@ -123,8 +123,8 @@ export class ImportDataService {
       {
         collection: 'category',
         collection_id: collectionKeys['category'],
-        field: 'name',
-        label: 'Name',
+        field: 'slug',
+        label: 'Slug',
         interface: 'input',
         readonly: false,
         required: false,
@@ -139,8 +139,8 @@ export class ImportDataService {
       {
         collection: 'tag',
         collection_id: collectionKeys['tag'],
-        field: 'slug',
-        label: 'Slug',
+        field: 'name',
+        label: 'Name',
         interface: 'input',
         readonly: false,
         required: false,
@@ -152,8 +152,8 @@ export class ImportDataService {
       {
         collection: 'tag',
         collection_id: collectionKeys['tag'],
-        field: 'name',
-        label: 'Name',
+        field: 'slug',
+        label: 'Slug',
         interface: 'input',
         readonly: false,
         required: false,


### PR DESCRIPTION
## What?
Sort order by name -> slug when importing from WordPress.

<!--
Write a brief description of your commitments.
-->

## Why?
Slug looks garbled.

<!--
Write the need for the ticket.
-->

## How?
Set name sort to 0 and slug sort to 1.

<!--
For user functionality additions, write the operating procedures.
For development modifications, write the configuration procedure.
For bug fixes, write the reproduction procedure.
-->