### PR TITLE
feat: support import of multiple WordPress xml

### DIFF
--- a/src/api/database/migrations/20230209234825_add-init-schema.ts
+++ b/src/api/database/migrations/20230209234825_add-init-schema.ts
@@ -31,6 +31,7 @@ export const up = async (knex: Knex): Promise<void> => {
     table.string('draft_value', 64);
     table.string('publish_value', 64);
     table.string('archive_value', 64);
+    table.string('source', 64);
     table.timestamps(true, true);
   });
 

--- a/src/api/database/overview.ts
+++ b/src/api/database/overview.ts
@@ -14,6 +14,7 @@ export type ModelOverview = {
   draftValue: string | null;
   publishValue: string | null;
   archiveValue: string | null;
+  source?: string | null;
   fields: {
     [name: string]: FieldOverview;
   };
@@ -67,6 +68,7 @@ export const getSchemaOverview = async (options?: { database?: Knex }): Promise<
       draftValue: metaModel ? metaModel.draft_value : null,
       publishValue: metaModel ? metaModel.publish_value : null,
       archiveValue: metaModel ? metaModel.archive_value : null,
+      source: metaModel ? metaModel.source : null,
       fields: Object.values(info.columns).reduce(
         (acc, column) => {
           const field = fields.find((f) => f.model === model && f.field === column.column_name);

--- a/src/api/database/schemas.ts
+++ b/src/api/database/schemas.ts
@@ -14,6 +14,7 @@ export type Model = {
   draft_value: string | null;
   publish_value: string | null;
   archive_value: string | null;
+  source?: string | null;
 } & TypeWithId;
 
 export type Field = {

--- a/src/api/database/seeds/dev.ts
+++ b/src/api/database/seeds/dev.ts
@@ -38,8 +38,8 @@ const resetAll = async (database: Knex): Promise<void> => {
   await database('collections_fields').delete();
   await database('collections_relations').delete();
   await database('collections_project_settings').delete();
-  await database.schema.dropTableIfExists('Post');
-  await database.schema.dropTableIfExists('Company');
+  await database.schema.dropTableIfExists('articles');
+  await database.schema.dropTableIfExists('companies');
 };
 
 const seedingSystemData = async (database: Knex): Promise<void> => {
@@ -83,26 +83,27 @@ const seedingSystemData = async (database: Knex): Promise<void> => {
     },
   ] as any[]);
 
-  // Model: Post
-  Output.info('Creating Post model...');
-  const postId = await modelsService.createModel(
+  // Model: Article
+  Output.info('Creating article model...');
+  const articleId = await modelsService.createModel(
     {
-      model: 'Post',
+      model: 'articles',
       singleton: false,
       hidden: false,
       status_field: null,
       draft_value: null,
       publish_value: null,
       archive_value: null,
+      source: null,
     },
     true
   );
 
-  // Fields: Post
-  Output.info('Creating Post fields...');
+  // Fields: Article
+  Output.info('Creating Article fields...');
   await fieldsService.createField({
-    model: 'Post',
-    model_id: postId,
+    model: 'articles',
+    model_id: articleId,
     field: 'title',
     label: 'Title',
     special: null,
@@ -115,8 +116,8 @@ const seedingSystemData = async (database: Knex): Promise<void> => {
   });
 
   await fieldsService.createField({
-    model: 'Post',
-    model_id: postId,
+    model: 'articles',
+    model_id: articleId,
     field: 'body',
     label: 'Body',
     special: null,
@@ -129,8 +130,8 @@ const seedingSystemData = async (database: Knex): Promise<void> => {
   });
 
   await fieldsService.createField({
-    model: 'Post',
-    model_id: postId,
+    model: 'articles',
+    model_id: articleId,
     field: 'author',
     label: 'Author',
     special: null,
@@ -146,13 +147,14 @@ const seedingSystemData = async (database: Knex): Promise<void> => {
   Output.info('Creating Company model...');
   const companyId = await modelsService.createModel(
     {
-      model: 'Company',
+      model: 'companies',
       singleton: true,
       hidden: false,
       status_field: null,
       draft_value: null,
       publish_value: null,
       archive_value: null,
+      source: null,
     },
     false
   );
@@ -160,7 +162,7 @@ const seedingSystemData = async (database: Knex): Promise<void> => {
   // Fields: Company
   Output.info('Creating Company fields...');
   await fieldsService.createField({
-    model: 'Company',
+    model: 'companies',
     model_id: companyId,
     field: 'name',
     label: 'Company Name',
@@ -174,7 +176,7 @@ const seedingSystemData = async (database: Knex): Promise<void> => {
   });
 
   await fieldsService.createField({
-    model: 'Company',
+    model: 'companies',
     model_id: companyId,
     field: 'email',
     label: 'Mail Address',
@@ -188,7 +190,7 @@ const seedingSystemData = async (database: Knex): Promise<void> => {
   });
 
   await fieldsService.createField({
-    model: 'Company',
+    model: 'companies',
     model_id: companyId,
     field: 'address',
     label: 'Address',
@@ -206,37 +208,37 @@ const seedingSystemData = async (database: Knex): Promise<void> => {
   await permissionsService.createMany([
     // Editor
     {
-      model: 'Post',
-      model_id: postId,
+      model: 'articles',
+      model_id: articleId,
       action: 'read',
       role_id: editorRole.id,
     },
     {
-      model: 'Post',
-      model_id: postId,
+      model: 'articles',
+      model_id: articleId,
       action: 'create',
       role_id: editorRole.id,
     },
     {
-      model: 'Post',
-      model_id: postId,
+      model: 'articles',
+      model_id: articleId,
       action: 'update',
       role_id: editorRole.id,
     },
     {
-      model: 'Company',
+      model: 'companies',
       model_id: companyId,
       action: 'read',
       role_id: editorRole.id,
     },
     {
-      model: 'Company',
+      model: 'companies',
       model_id: companyId,
       action: 'create',
       role_id: editorRole.id,
     },
     {
-      model: 'Company',
+      model: 'companies',
       model_id: companyId,
       action: 'update',
       role_id: editorRole.id,
@@ -256,8 +258,8 @@ const seedingContentData = async (database: Knex): Promise<void> => {
   const schema = await getSchemaOverview({ database });
 
   Output.info('Adding content data...');
-  const postsService = new ContentsService('Post', { database, schema });
-  await postsService.createMany([
+  const articlesService = new ContentsService('articles', { database, schema });
+  await articlesService.createMany([
     {
       title: 'Makes migration from legacy CMS seamless',
       body: 'Collections is open source Headless CMS built with React, Node.js, RDB. We are planning an importer to make the transition from a legacy CMS.',
@@ -290,7 +292,7 @@ const seedingContentData = async (database: Knex): Promise<void> => {
     },
   ]);
 
-  const companiesService = new ContentsService('Company', { database, schema });
+  const companiesService = new ContentsService('companies', { database, schema });
   await companiesService.createMany([
     {
       name: 'Rocketa Inc.',

--- a/src/api/services/fields.ts
+++ b/src/api/services/fields.ts
@@ -228,11 +228,12 @@ export class FieldsService extends BaseService<Field> {
   }
 
   private async checkUniqueField(model: string, field: string) {
-    const fields = await this.readMany({
-      filter: {
-        _and: [{ model: { _eq: model } }, { field: { _eq: field } }],
-      },
-    });
+    // TODO add to applyFilter
+    const fields = await this.database
+      .select('id')
+      .from('collections_fields')
+      .where('model', model)
+      .whereRaw('LOWER(??) = ?', ['field', field.toLowerCase()]);
 
     if (fields.length) {
       throw new RecordNotUniqueException('already_registered_name');

--- a/src/api/services/importData.ts
+++ b/src/api/services/importData.ts
@@ -66,17 +66,17 @@ export class ImportDataService {
       const result = await parseFromFile(buffer.toString());
       const schema = await getSchemaOverview({ database: tx });
 
-      await this.createContents('category', tx, schema, result.categories);
-      await this.createContents('tag', tx, schema, result.tags);
-      await this.createContents('post', tx, schema, result.posts);
+      await this.createContents('categories', tx, schema, result.categories);
+      await this.createContents('tags', tx, schema, result.tags);
+      await this.createContents('posts', tx, schema, result.posts);
     });
   }
 
   private async createModels(tx: Knex.Transaction): Promise<Record<string, PrimaryKey>> {
     const models = [
-      { model: 'category', hasStatus: false },
-      { model: 'tag', hasStatus: false },
-      { model: 'post', hasStatus: true },
+      { model: 'categories', hasStatus: false },
+      { model: 'tags', hasStatus: false },
+      { model: 'posts', hasStatus: true },
     ];
 
     const result: Record<string, PrimaryKey> = {};
@@ -109,8 +109,8 @@ export class ImportDataService {
   ): Promise<void> {
     const categoryFields: Omit<Field, 'id'>[] = [
       {
-        model: 'category',
-        model_id: modelKeys['category'],
+        model: 'categories',
+        model_id: modelKeys['categories'],
         field: 'name',
         label: 'Name',
         interface: 'input',
@@ -122,8 +122,8 @@ export class ImportDataService {
         sort: 0,
       },
       {
-        model: 'category',
-        model_id: modelKeys['category'],
+        model: 'categories',
+        model_id: modelKeys['categories'],
         field: 'slug',
         label: 'Slug',
         interface: 'input',
@@ -138,8 +138,8 @@ export class ImportDataService {
 
     const tagFields: Omit<Field, 'id'>[] = [
       {
-        model: 'tag',
-        model_id: modelKeys['tag'],
+        model: 'tags',
+        model_id: modelKeys['tags'],
         field: 'name',
         label: 'Name',
         interface: 'input',
@@ -151,8 +151,8 @@ export class ImportDataService {
         sort: 0,
       },
       {
-        model: 'tag',
-        model_id: modelKeys['tag'],
+        model: 'tags',
+        model_id: modelKeys['tags'],
         field: 'slug',
         label: 'Slug',
         interface: 'input',
@@ -167,8 +167,8 @@ export class ImportDataService {
 
     const postFields: Omit<Field, 'id'>[] = [
       {
-        model: 'post',
-        model_id: modelKeys['post'],
+        model: 'posts',
+        model_id: modelKeys['posts'],
         field: 'title',
         label: 'Title',
         interface: 'input',
@@ -180,8 +180,8 @@ export class ImportDataService {
         sort: 0,
       },
       {
-        model: 'post',
-        model_id: modelKeys['post'],
+        model: 'posts',
+        model_id: modelKeys['posts'],
         field: 'content',
         label: 'Content',
         interface: 'inputRichTextMd', // TODO: Change to 'inputRichTextHtml'
@@ -193,8 +193,8 @@ export class ImportDataService {
         sort: 1,
       },
       {
-        model: 'post',
-        model_id: modelKeys['post'],
+        model: 'posts',
+        model_id: modelKeys['posts'],
         field: 'slug',
         label: 'Slug',
         interface: 'input',
@@ -206,8 +206,8 @@ export class ImportDataService {
         sort: 2,
       },
       {
-        model: 'post',
-        model_id: modelKeys['post'],
+        model: 'posts',
+        model_id: modelKeys['posts'],
         field: 'published_date',
         label: 'publishedDate',
         interface: 'dateTime',
@@ -219,8 +219,8 @@ export class ImportDataService {
         sort: 3,
       },
       {
-        model: 'post',
-        model_id: modelKeys['post'],
+        model: 'posts',
+        model_id: modelKeys['posts'],
         field: 'is_page',
         label: 'isPage',
         interface: 'boolean',
@@ -249,17 +249,17 @@ export class ImportDataService {
 
     await fieldsService.createRelationalFields(
       {
-        many_model: 'category',
-        many_model_id: modelKeys['category'],
+        many_model: 'categories',
+        many_model_id: modelKeys['categories'],
         many_field: 'post_id',
-        one_model: 'post',
-        one_model_id: modelKeys['post'],
+        one_model: 'posts',
+        one_model_id: modelKeys['posts'],
         one_field: 'categories',
       },
       [
         {
-          model: 'post',
-          model_id: modelKeys['post'],
+          model: 'posts',
+          model_id: modelKeys['posts'],
           field: 'categories',
           label: 'Categories',
           interface: 'listOneToMany',
@@ -271,8 +271,8 @@ export class ImportDataService {
           sort: 10,
         },
         {
-          model: 'category',
-          model_id: modelKeys['category'],
+          model: 'categories',
+          model_id: modelKeys['categories'],
           field: 'post_id',
           label: 'Post Id',
           interface: 'selectDropdownManyToOne',
@@ -292,17 +292,17 @@ export class ImportDataService {
 
     await fieldsService.createRelationalFields(
       {
-        many_model: 'tag',
-        many_model_id: modelKeys['tag'],
+        many_model: 'tags',
+        many_model_id: modelKeys['tags'],
         many_field: 'post_id',
-        one_model: 'post',
-        one_model_id: modelKeys['post'],
+        one_model: 'posts',
+        one_model_id: modelKeys['posts'],
         one_field: 'tags',
       },
       [
         {
-          model: 'post',
-          model_id: modelKeys['post'],
+          model: 'posts',
+          model_id: modelKeys['posts'],
           field: 'tags',
           label: 'Tags',
           interface: 'listOneToMany',
@@ -314,8 +314,8 @@ export class ImportDataService {
           sort: 10,
         },
         {
-          model: 'tag',
-          model_id: modelKeys['tag'],
+          model: 'tags',
+          model_id: modelKeys['tags'],
           field: 'post_id',
           label: 'Post Id',
           interface: 'selectDropdownManyToOne',

--- a/src/api/services/importData.ts
+++ b/src/api/services/importData.ts
@@ -92,6 +92,7 @@ export class ImportDataService {
           draft_value: null,
           publish_value: null,
           archive_value: null,
+          source: 'wordpress',
         },
         hasStatus
       );

--- a/src/api/services/importData.ts
+++ b/src/api/services/importData.ts
@@ -48,7 +48,7 @@ export class ImportDataService {
     });
 
     if (models.length > 0) {
-      throw new RecordNotUniqueException('already_registered_name');
+      throw new RecordNotUniqueException('already_registered_model');
     }
 
     await service.database.transaction(async (tx) => {

--- a/src/api/services/models.ts
+++ b/src/api/services/models.ts
@@ -237,7 +237,7 @@ export class ModelsService extends BaseService<Model> {
     });
 
     if (models.length) {
-      throw new RecordNotUniqueException('already_registered_name');
+      throw new RecordNotUniqueException('already_registered_model');
     }
   }
 }

--- a/src/api/services/models.ts
+++ b/src/api/services/models.ts
@@ -232,9 +232,11 @@ export class ModelsService extends BaseService<Model> {
   };
 
   private async checkUniqueModel(model: string) {
-    const models = await this.readMany({
-      filter: { model: { _eq: model } },
-    });
+    // TODO add to applyFilter
+    const models = await this.database
+      .select('id')
+      .from('collections_models')
+      .whereRaw('LOWER(??) = ?', ['model', model.toLowerCase()]);
 
     if (models.length) {
       throw new RecordNotUniqueException('already_registered_model');

--- a/src/lang/translations/en/translation.json
+++ b/src/lang/translations/en/translation.json
@@ -181,6 +181,7 @@
     "forbidden": "You don't have permission to access this.",
     "already_registered_email": "Already registered email.",
     "already_registered_name": "Already registered.",
+    "already_registered_model": "Already registered data model.",
     "unregistered_email_address": "Unregistered email address.",
     "token_invalid_or_expired": "Token is either invalid or has expired.",
     "record_not_found": "Record not found.",

--- a/src/lang/translations/ja/translation.json
+++ b/src/lang/translations/ja/translation.json
@@ -181,6 +181,7 @@
     "forbidden": "アクセスする権限がありません。",
     "already_registered_email": "すでに登録済みのメールアドレスです。",
     "already_registered_name": "すでに登録済みです。",
+    "already_registered_model": "データモデルがすでに使われています。",
     "unregistered_email_address": "登録されていないメールアドレスです。",
     "token_invalid_or_expired": "トークンが無効であるか、有効期限が切れています。",
     "record_not_found": "レコードが見つかりません。",

--- a/test/api/database/overview.test.ts
+++ b/test/api/database/overview.test.ts
@@ -48,6 +48,7 @@ describe('Schema Overview', () => {
         draftValue: null,
         publishValue: null,
         archiveValue: null,
+        source: null,
         fields: {
           id: { alias: false, special: null, field: 'id' },
           model: { alias: false, special: null, field: 'model' },
@@ -57,6 +58,7 @@ describe('Schema Overview', () => {
           draft_value: { alias: false, special: null, field: 'draft_value' },
           publish_value: { alias: false, special: null, field: 'publish_value' },
           archive_value: { alias: false, special: null, field: 'archive_value' },
+          source: { alias: false, special: null, field: 'source' },
           created_at: { alias: false, special: null, field: 'created_at' },
           updated_at: { alias: false, special: null, field: 'updated_at' },
         },
@@ -72,6 +74,7 @@ describe('Schema Overview', () => {
         draftValue: null,
         publishValue: null,
         archiveValue: null,
+        source: null,
         fields: {
           id: { alias: false, special: null, field: 'id' },
           circuit: { alias: false, special: null, field: 'circuit' },

--- a/test/api/services/importData.test.ts
+++ b/test/api/services/importData.test.ts
@@ -2,7 +2,6 @@ import knex, { Knex } from 'knex';
 import { SchemaOverview, getSchemaOverview } from '../../../src/api/database/overview.js';
 import { ContentsService } from '../../../src/api/services/contents.js';
 import { ImportDataService } from '../../../src/api/services/importData.js';
-import { RecordNotUniqueException } from '../../../src/exceptions/database/recordNotUnique.js';
 import { UnsupportedMediaTypeException } from '../../../src/exceptions/unsupportedMediaType.js';
 import { config } from '../../config.js';
 import { wordPressXml } from '../../utilities/factories.js';
@@ -40,6 +39,61 @@ describe('ImportDataService', () => {
   };
 
   describe('Import', () => {
+    afterEach(async () => {
+      for (const [_, connection] of databases) {
+        if (await connection.schema.hasTable('categories')) {
+          await connection.delete().from('categories');
+        }
+
+        if (await connection.schema.hasTable('tags')) {
+          await connection.delete().from('tags');
+        }
+
+        if (await connection.schema.hasTable('posts')) {
+          await connection.delete().from('posts');
+        }
+      }
+    });
+
+    const expectedCategoryData = [
+      expect.objectContaining({
+        name: 'Uncategorized',
+        slug: 'uncategorized',
+      }),
+      expect.objectContaining({
+        name: 'blog',
+        slug: 'blog',
+      }),
+    ];
+
+    const expectedTagData = [
+      expect.objectContaining({
+        name: 'post',
+        slug: 'post',
+      }),
+    ];
+
+    const expectedPostData = [
+      expect.objectContaining({
+        title: 'Hello world!',
+        status: 'published',
+        slug: 'hello-world',
+        is_page: false,
+      }),
+      expect.objectContaining({
+        title: 'Sample Page',
+        status: 'published',
+        slug: 'sample-page',
+        is_page: true,
+      }),
+      expect.objectContaining({
+        title: 'Privacy Policy',
+        status: 'draft',
+        slug: 'privacy-policy',
+        is_page: true,
+      }),
+    ];
+
     it.each(testDatabases)('%s - should throw UnsupportedMediaTypeException', async (database) => {
       const connection = databases.get(database)!;
       const schema = await getSchemaOverview({ database: connection });
@@ -67,60 +121,44 @@ describe('ImportDataService', () => {
 
         schema = await getSchemaOverview({ database: connection });
 
-        // categories
-        await assertExpectedData(connection, schema, 'categories', [
-          expect.objectContaining({
-            name: 'Uncategorized',
-            slug: 'uncategorized',
-          }),
-          expect.objectContaining({
-            name: 'blog',
-            slug: 'blog',
-          }),
-        ]);
-
-        // tags
-        await assertExpectedData(connection, schema, 'tags', [
-          expect.objectContaining({
-            name: 'post',
-            slug: 'post',
-          }),
-        ]);
-
-        // posts
-        await assertExpectedData(connection, schema, 'posts', [
-          expect.objectContaining({
-            title: 'Hello world!',
-            status: 'published',
-            slug: 'hello-world',
-            is_page: false,
-          }),
-          expect.objectContaining({
-            title: 'Sample Page',
-            status: 'published',
-            slug: 'sample-page',
-            is_page: true,
-          }),
-          expect.objectContaining({
-            title: 'Privacy Policy',
-            status: 'draft',
-            slug: 'privacy-policy',
-            is_page: true,
-          }),
-        ]);
+        await assertExpectedData(connection, schema, 'categories', expectedCategoryData);
+        await assertExpectedData(connection, schema, 'tags', expectedTagData);
+        await assertExpectedData(connection, schema, 'posts', expectedPostData);
       },
       20_000
     );
 
-    it.each(testDatabases)('%s - should throw RecordNotUniqueException', async (database) => {
-      const connection = databases.get(database)!;
-      const schema = await getSchemaOverview({ database: connection });
-      const service = new ImportDataService({ database: connection, schema });
+    it.each(testDatabases)(
+      '%s - should be possible to import twice',
+      async (database) => {
+        const connection = databases.get(database)!;
+        let schema = await getSchemaOverview({ database: connection });
 
-      const buffer = Buffer.from(wordPressXml);
-      const mimetype = 'text/xml';
+        const buffer = Buffer.from(wordPressXml);
+        const mimetype = 'text/xml';
 
-      await expect(service.importData(mimetype, buffer)).rejects.toThrow(RecordNotUniqueException);
-    });
+        const service = new ImportDataService({ database: connection, schema });
+        // first times
+        await service.importData(mimetype, buffer);
+        // second times
+        await service.importData(mimetype, buffer);
+
+        schema = await getSchemaOverview({ database: connection });
+
+        await assertExpectedData(connection, schema, 'categories', [
+          ...expectedCategoryData,
+          ...expectedCategoryData,
+        ]);
+        await assertExpectedData(connection, schema, 'tags', [
+          ...expectedTagData,
+          ...expectedTagData,
+        ]);
+        await assertExpectedData(connection, schema, 'posts', [
+          ...expectedPostData,
+          ...expectedPostData,
+        ]);
+      },
+      20_000
+    );
   });
 });

--- a/test/api/services/importData.test.ts
+++ b/test/api/services/importData.test.ts
@@ -67,8 +67,8 @@ describe('ImportDataService', () => {
 
         schema = await getSchemaOverview({ database: connection });
 
-        // category
-        await assertExpectedData(connection, schema, 'category', [
+        // categories
+        await assertExpectedData(connection, schema, 'categories', [
           expect.objectContaining({
             name: 'Uncategorized',
             slug: 'uncategorized',
@@ -79,16 +79,16 @@ describe('ImportDataService', () => {
           }),
         ]);
 
-        // tag
-        await assertExpectedData(connection, schema, 'tag', [
+        // tags
+        await assertExpectedData(connection, schema, 'tags', [
           expect.objectContaining({
             name: 'post',
             slug: 'post',
           }),
         ]);
 
-        // post
-        await assertExpectedData(connection, schema, 'post', [
+        // posts
+        await assertExpectedData(connection, schema, 'posts', [
           expect.objectContaining({
             title: 'Hello world!',
             status: 'published',

--- a/test/setups/teardown.ts
+++ b/test/setups/teardown.ts
@@ -39,9 +39,9 @@ async function dropModels(database: Knex) {
     'model_f1_grand_prix_races',
     'model_f1_ferrari_team_stats',
     'model_f1_grand_prix_race_stats',
-    'category',
-    'tag',
-    'post',
+    'categories',
+    'tags',
+    'posts',
   ];
 
   for (const tableName of tableNames) {


### PR DESCRIPTION
## What?
Support import of multiple WordPress xml.

<!--
Write a brief description of your commitments.
-->

## Why?
Core experience of the service.

<!--
Write the need for the ticket.
-->

## How?
- Add source field, labeling imports from WordPress
- If a table exists, only register data
- Refactor
  - Change model name to plural
  - Seed data post changed to articles

<!--
For user functionality additions, write the operating procedures.
For development modifications, write the configuration procedure.
For bug fixes, write the reproduction procedure.
-->
