### PR TITLE
feat: add feedback to navigation bar

### DIFF
--- a/docs/pages/docs/app-guides/config-options.en.mdx
+++ b/docs/pages/docs/app-guides/config-options.en.mdx
@@ -118,8 +118,9 @@ MIGRATE_EXTENSIONS=".js"
 | EMAIL_FROM             | Email Source Email Address | --            |
 | EMAIL_SENDGRID_API_KEY | API key for sendgrid       | --            |
 
-## Analytics
+## Other
 
 | Variable                | Description                    | Default Value |
 | :---------------------- | :----------------------------- | :------------ |
 | WEBPACK_BUNDLE_ANALYZER | Launch Webpack Bundle Analyzer | --            |
+| PUBLIC_SHOW_NAVIGATION_CARD | Display of navigation cards for feedback. | `true` |

--- a/docs/pages/docs/app-guides/config-options.ja.mdx
+++ b/docs/pages/docs/app-guides/config-options.ja.mdx
@@ -118,8 +118,9 @@ MIGRATE_EXTENSIONS = '.js';
 | EMAIL_FROM             | email の送信元メールアドレス | --         |
 | EMAIL_SENDGRID_API_KEY | sendgrid の API キー         | --         |
 
-## Analytics
+## Other
 
 | 変数名                  | 説明                          | 初期値 |
 | :---------------------- | :---------------------------- | :----- |
 | WEBPACK_BUNDLE_ANALYZER | Webpack Bundle Analyzerの起動 | --     |
+| PUBLIC_SHOW_NAVIGATION_CARD | フィードバック用ナビゲーションカードの表示 | `true` |

--- a/src/admin/components/elements/NavContent/BottomContent/index.tsx
+++ b/src/admin/components/elements/NavContent/BottomContent/index.tsx
@@ -1,5 +1,5 @@
 import { BugOutlined, LogoutOutlined } from '@ant-design/icons';
-import { Box, Stack, Tooltip } from '@mui/material';
+import { Box, Divider, Stack, Tooltip } from '@mui/material';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -31,7 +31,7 @@ export const BottomContent: React.FC = () => {
         confirm={{ label: t('logout'), action: handleLogout }}
         cancel={{ label: t('cancel'), action: () => setLogoutDialogOpen(false) }}
       />
-      <Stack direction="row" spacing={2}>
+      <Stack direction="row" divider={<Divider orientation="vertical" flexItem />} spacing={2}>
         <Tooltip title={t('report_bug')} arrow>
           <Box sx={{ flexShrink: 0 }}>
             <IconButton

--- a/src/admin/components/elements/NavContent/NavCard/index.tsx
+++ b/src/admin/components/elements/NavContent/NavCard/index.tsx
@@ -1,0 +1,25 @@
+import { MainCard } from '@collectionscms/plugin-ui';
+import { Link, Stack, Typography } from '@mui/material';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export const NavCard = () => {
+  const { t } = useTranslation();
+
+  return (
+    <MainCard sx={{ bgcolor: 'grey.50', m: 3 }}>
+      <Stack alignItems="center" spacing={2} sx={{ whiteSpace: 'break-spaces' }}>
+        <Stack alignItems="center">
+          <Typography variant="h6" color="secondary">
+            {t('how_was_it')}
+          </Typography>
+          <Typography variant="h6">
+            <Link href={t('feedback_google_form')} target="_blank" rel="noopener noreferrer">
+              {t('leaving_feedback')}
+            </Link>
+          </Typography>
+        </Stack>
+      </Stack>
+    </MainCard>
+  );
+};

--- a/src/admin/components/elements/NavContent/index.tsx
+++ b/src/admin/components/elements/NavContent/index.tsx
@@ -11,6 +11,7 @@ import { NavGroup } from '../NavGroup/index.js';
 import { NavHeader } from '../NavHeader/index.js';
 import { ScrollBar } from '../ScrollBar/index.js';
 import { BottomContent } from './BottomContent/index.js';
+import { NavCard } from './NavCard/index.js';
 
 export const NavContent: React.FC = () => {
   const { user } = useAuth();
@@ -39,6 +40,7 @@ export const NavContent: React.FC = () => {
       >
         {navHeader}
         {navGroups}
+        {process.env.PUBLIC_SHOW_NAVIGATION_CARD === 'true' && <NavCard />}
       </ScrollBar>
       <Divider sx={{ mx: 1 }} />
       <Box

--- a/src/env.ts
+++ b/src/env.ts
@@ -111,9 +111,10 @@ type AllowedEnvironmentVariable =
   | 'EMAIL_SENDGRID_API_KEY'
 
   // /////////////////////////////////////
-  // Analytics
+  // Other
   // /////////////////////////////////////
-  | 'WEBPACK_BUNDLE_ANALYZER';
+  | 'WEBPACK_BUNDLE_ANALYZER'
+  | 'PUBLIC_SHOW_NAVIGATION_CARD';
 
 export const defaults: Partial<Record<AllowedEnvironmentVariable, any>> = {
   // General
@@ -167,6 +168,9 @@ export const defaults: Partial<Record<AllowedEnvironmentVariable, any>> = {
   // Email
   EMAIL_TRANSPORT: 'sendgrid',
   EMAIL_FROM: 'no-reply@example.com',
+
+  // Other
+  PUBLIC_SHOW_NAVIGATION_CARD: true,
 };
 
 export let env: Record<string, any> = {

--- a/src/lang/translations/en/translation.json
+++ b/src/lang/translations/en/translation.json
@@ -120,6 +120,9 @@
   "january": "Jan",
   "report_bug": "Report Bug",
   "writing": "Writing",
+  "how_was_it": "How was it?",
+  "leaving_feedback": "Leaving Feedback",
+  "feedback_google_form": "https://docs.google.com/forms/d/e/1FAIpQLSf_-GobuuYmEiUvtED93RqVEb_nempT4x3f2ueO3C77f3mluQ/viewform?usp=sf_link",
   "dialog": {
     "confirm_deletion_title": "Confirm deletion.",
     "confirm_deletion": "Once deleted, it cannot be restored. Are you sure you want to delete it?",

--- a/src/lang/translations/ja/translation.json
+++ b/src/lang/translations/ja/translation.json
@@ -120,6 +120,9 @@
   "january": "1月",
   "report_bug": "バグを報告",
   "writing": "書き方",
+  "how_was_it": "体験はいかがですか？",
+  "leaving_feedback": "フィードバックする",
+  "feedback_google_form": "https://docs.google.com/forms/d/e/1FAIpQLSfn-ubYtGufApDMPMCzYyNKj4rLoJD79qJ-1OWpqERVB9oikA/viewform?usp=sf_link",
   "dialog": {
     "confirm_deletion_title": "削除の確認",
     "confirm_deletion": "一度削除すると復元できません。削除してよろしいですか？",


### PR DESCRIPTION
## What?
Add feedback cards to the navigation bar, but offer the option to hide them due to potential noise.

![スクリーンショット 2023-11-23 19 19 09](https://github.com/collectionscms/collections/assets/59549200/442b7595-ba18-4334-afa5-13c9cd48504f)

<!--
Write a brief description of your commitments.
-->

## Why?
Want more feedback for improvement.

<!--
Write the need for the ticket.
-->

## Notes
Add env var `PUBLIC_SHOW_NAVIGATION_CARD`.