### PR TITLE
feat: change contents API parameter from modelId to identifier

### DIFF
--- a/docs/data/api.yaml
+++ b/docs/data/api.yaml
@@ -284,13 +284,13 @@ paths:
   ## #####################################
   ## Contents
   ## #####################################
-  /api/models/{modelId}/contents:
+  /api/models/{identifier}/contents:
     get:
       summary: Get contents
       description: Return contents. Returns fields defined in the model in addition to id and timestamp.
       operationId: getContents
       parameters:
-        - $ref: '#/components/parameters/modelId'
+        - $ref: '#/components/parameters/identifier'
       responses:
         '200':
           description: ''
@@ -306,13 +306,13 @@ paths:
       security:
         - bearerAuth: []
         - apiKeyAuth: []
-  /api/models/{modelId}/contents/{id}:
+  /api/models/{identifier}/contents/{id}:
     get:
       summary: Get content
       description: Return content. Returns fields defined in the model in addition to id and timestamp.
       operationId: getContent
       parameters:
-        - $ref: '#/components/parameters/modelId'
+        - $ref: '#/components/parameters/identifier'
         - $ref: '#/components/parameters/id'
       responses:
         '200':
@@ -332,7 +332,7 @@ paths:
       description: Update content. Post fields defined in the model.
       operationId: updateContent
       parameters:
-        - $ref: '#/components/parameters/modelId'
+        - $ref: '#/components/parameters/identifier'
         - $ref: '#/components/parameters/id'
       responses:
         '204':
@@ -345,7 +345,7 @@ paths:
       description: Delete content.
       operationId: deleteContent
       parameters:
-        - $ref: '#/components/parameters/modelId'
+        - $ref: '#/components/parameters/identifier'
         - $ref: '#/components/parameters/id'
       responses:
         '204':
@@ -353,13 +353,13 @@ paths:
       security:
         - bearerAuth: []
         - apiKeyAuth: []
-  /api/models/{modelId}/contents/:
+  /api/models/{identifier}/contents/:
     post:
       summary: Create content
       description: Create content. Post fields defined in the model.
       operationId: createContent
       parameters:
-        - $ref: '#/components/parameters/modelId'
+        - $ref: '#/components/parameters/identifier'
       responses:
         '200':
           description: ''
@@ -426,6 +426,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/id'
+    identifier:
+      name: identifier
+      in: path
+      description: Primary key or name for model
+      required: true
+      schema:
+        $ref: '#/components/schemas/identifier'
     field:
       name: field
       in: path
@@ -443,6 +450,12 @@ components:
       description: Primary Key
       example: 1
       type: integer
+    identifier:
+      description: Primary key or name for model
+      example:
+        - 1
+        - 'zoo'
+      type: string
     createdAt:
       description: Created At
       example: '2023-09-29T00:53:20.604Z'

--- a/docs/pages/reference/api.ja.mdx
+++ b/docs/pages/reference/api.ja.mdx
@@ -7,7 +7,7 @@ import { RedocStandalone } from 'redoc';
 import { useData } from 'nextra/data';
 
 export const getStaticProps = ({ params }) => {
-  return fetch(`https://collections.dev/api/openapi`)
+  return fetch(`${process.env.NEXT_PUBLIC_API_ENDPOINT}/api/openapi`)
     .then((res) => res.json())
     .then((repo) => ({
       props: {

--- a/src/api/controllers/contents.ts
+++ b/src/api/controllers/contents.ts
@@ -8,7 +8,7 @@ import { ContentsService } from '../services/contents.js';
 const router = express.Router();
 
 router.get(
-  '/models/:modelId/contents',
+  '/models/:identifier/contents',
   modelExists,
   modelPermissionsHandler('read'),
   asyncHandler(async (req: Request, res: Response) => {
@@ -26,7 +26,7 @@ router.get(
 );
 
 router.get(
-  '/models/:modelId/contents/:id',
+  '/models/:identifier/contents/:id',
   modelExists,
   modelPermissionsHandler('read'),
   asyncHandler(async (req: Request, res: Response) => {
@@ -47,7 +47,7 @@ router.get(
 );
 
 router.post(
-  '/models/:modelId/contents',
+  '/models/:identifier/contents',
   modelExists,
   modelPermissionsHandler('create'),
   asyncHandler(async (req: Request, res: Response) => {
@@ -66,7 +66,7 @@ router.post(
 );
 
 router.patch(
-  '/models/:modelId/contents/:id',
+  '/models/:identifier/contents/:id',
   modelExists,
   modelPermissionsHandler('update'),
   asyncHandler(async (req: Request, res: Response) => {
@@ -81,7 +81,7 @@ router.patch(
 );
 
 router.delete(
-  '/models/:modelId/contents/:id',
+  '/models/:identifier/contents/:id',
   modelExists,
   modelPermissionsHandler('delete'),
   asyncHandler(async (req: Request, res: Response) => {

--- a/src/api/middleware/modelExists.ts
+++ b/src/api/middleware/modelExists.ts
@@ -4,10 +4,14 @@ import { asyncHandler } from './asyncHandler.js';
 
 export const modelExists: RequestHandler = asyncHandler(
   async (req: Request, _res: Response, next: NextFunction) => {
-    if (!req.params.modelId) return next();
+    const identifier = req.params.identifier;
+    if (!identifier) return next();
 
     for (const model of Object.values(req.schema.models)) {
-      if (model.id?.toString() === req.params.modelId) {
+      if (
+        model.id?.toString() === identifier ||
+        model.model.toLowerCase() === identifier.toLowerCase()
+      ) {
         req.model = model;
         return next();
       }

--- a/test/api/middleware/modelExists.test.ts
+++ b/test/api/middleware/modelExists.test.ts
@@ -1,0 +1,68 @@
+import { jest } from '@jest/globals';
+import { NextFunction, Request, Response, response } from 'express';
+import { modelExists } from '../../../src/api/middleware/modelExists.js';
+
+describe('ModelExists middleware', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let nextFunction: NextFunction = jest.fn();
+
+  describe('modelExists', () => {
+    beforeEach(() => {
+      mockRequest = {
+        schema: {
+          models: {
+            1: {
+              id: 1,
+              model: 'mock_model',
+              singleton: false,
+              statusField: null,
+              draftValue: null,
+              publishValue: null,
+              archiveValue: null,
+              fields: {
+                id: { alias: false, special: null, field: 'id' },
+                createdAt: { alias: false, special: null, field: 'createdAt' },
+                updatedAt: { alias: false, special: null, field: 'updatedAt' },
+                date: { alias: false, special: 'cast-timestamp', field: 'date' },
+              },
+            },
+          },
+          relations: [],
+        },
+      };
+    });
+
+    it('should get model by id', () => {
+      mockRequest.params = {
+        identifier: '1',
+      };
+
+      modelExists(mockRequest as Request, mockResponse as Response, nextFunction);
+      expect(mockRequest.model?.model).toBe('mock_model');
+    });
+
+    it('should get model by name', () => {
+      mockRequest.params = {
+        identifier: 'mock_model',
+      };
+
+      modelExists(mockRequest as Request, mockResponse as Response, nextFunction);
+      expect(mockRequest.model?.id).toBe(1);
+    });
+
+    it('should call next function', () => {
+      modelExists(mockRequest as Request, mockResponse as Response, nextFunction);
+      expect(nextFunction).toHaveBeenCalled();
+    });
+
+    it('should throw forbidden', async () => {
+      mockRequest.params = {
+        identifier: 'no_exist_model',
+      };
+
+      modelExists(mockRequest as Request, mockResponse as Response, nextFunction);
+      expect(mockRequest.model).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## What?
Change contents API parameter from modelId to identifier.

Before:
```
/api/models/:modelId/contents
/api/models/:modelId/contents/:id
```

After:
```
/api/models/:identifier/contents
/api/models/:identifier/contents/:id
```

<!--
Write a brief description of your commitments.
-->

## Why?
Name is far more visible than id.

<!--
Write the need for the ticket.
-->

## How?
You can get contents in two ways.
```
/api/models/1/contents
/api/models/Posts/contents
```

<!--
For user functionality additions, write the operating procedures.
For development modifications, write the configuration procedure.
For bug fixes, write the reproduction procedure.
-->
