### PR TITLE
test: [Workaround] fix jest execution failures

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,9 +16,17 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['18.18.x']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Yarn install
         run: yarn install
@@ -35,9 +43,17 @@ jobs:
   unit:
     name: Unit Tests
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['18.18.x']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Yarn install
         run: yarn install

--- a/.github/workflows/integration-full.yml
+++ b/.github/workflows/integration-full.yml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        node-version: ['18.18.x']
         database:
           - sqlite3
           - mysql
@@ -32,6 +33,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Yarn install
         run: yarn install

--- a/.github/workflows/integration-single.yml
+++ b/.github/workflows/integration-single.yml
@@ -13,9 +13,17 @@ jobs:
   integration:
     name: sqlite3
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['18.18.x']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Yarn install
         run: yarn install


### PR DESCRIPTION
## What?
Jest fails with the following exceptions.

```
Error: Jest: Got error running globalSetup - /Users/zane/project/collections/test/setups/setup.ts, reason: Cannot find module '../config.js'
```

<!--
Write a brief description of your commitments.
-->

## Why?
GitHub Actions image was updated on December 5th, and Node is now at version `18.19`.
https://github.com/actions/runner-images/blob/ubuntu22/20231205.1/images/ubuntu/Ubuntu2204-Readme.md

same error:
https://github.com/TypeStrong/ts-node/issues/2094
https://github.com/TypeStrong/ts-node/issues/1997

<!--
Write the need for the ticket.
-->

## How?
Fix node version to be tested to `18.18.x`.

<!--
For user functionality additions, write the operating procedures.
For development modifications, write the configuration procedure.
For bug fixes, write the reproduction procedure.
-->