### PR TITLE
refactor: merge prismaType into bypassPrismaType

### DIFF
--- a/src/api/data/project/project.repository.ts
+++ b/src/api/data/project/project.repository.ts
@@ -1,5 +1,5 @@
 import { Project } from '@prisma/client';
-import { PrismaType, ProjectPrismaType } from '../../database/prisma/client.js';
+import { BypassPrismaType, ProjectPrismaType } from '../../database/prisma/client.js';
 import { ProjectEntity } from './project.entity.js';
 
 export class ProjectRepository {
@@ -11,7 +11,7 @@ export class ProjectRepository {
     return ProjectEntity.Reconstruct<Project, ProjectEntity>(record);
   }
 
-  async findOneBySubdomain(prisma: PrismaType, subdomain: string): Promise<ProjectEntity> {
+  async findOneBySubdomain(prisma: BypassPrismaType, subdomain: string): Promise<ProjectEntity> {
     const record = await prisma.project.findFirstOrThrow({
       where: {
         subdomain: subdomain,

--- a/src/api/data/user/user.repository.ts
+++ b/src/api/data/user/user.repository.ts
@@ -2,7 +2,7 @@ import { User } from '@auth/express';
 import { Permission, Project, Role } from '@prisma/client';
 import { RecordNotUniqueException } from '../../../exceptions/database/recordNotUnique.js';
 import { InvalidCredentialsException } from '../../../exceptions/invalidCredentials.js';
-import { BypassPrismaType, PrismaType, ProjectPrismaType } from '../../database/prisma/client.js';
+import { BypassPrismaType, ProjectPrismaType } from '../../database/prisma/client.js';
 import { comparePasswords } from '../../utilities/comparePasswords.js';
 import { PermissionEntity } from '../permission/permission.entity.js';
 import { ProjectEntity } from '../project/project.entity.js';
@@ -27,7 +27,7 @@ export class UserRepository {
     return UserEntity.Reconstruct<User, UserEntity>(user);
   }
 
-  async findOneById(prisma: PrismaType, userId: string): Promise<UserEntity> {
+  async findOneById(prisma: BypassPrismaType, userId: string): Promise<UserEntity> {
     const record = await prisma.user.findFirstOrThrow({
       where: {
         id: userId,
@@ -37,7 +37,7 @@ export class UserRepository {
     return UserEntity.Reconstruct<User, UserEntity>(record);
   }
 
-  async findOneByEmail(prisma: PrismaType, email: string): Promise<UserEntity | null> {
+  async findOneByEmail(prisma: BypassPrismaType, email: string): Promise<UserEntity | null> {
     const user = await prisma.user.findFirst({
       where: {
         email,
@@ -47,7 +47,10 @@ export class UserRepository {
     return user ? UserEntity.Reconstruct<User, UserEntity>(user) : null;
   }
 
-  async findOneByConfirmationToken(prisma: PrismaType, token: string): Promise<UserEntity | null> {
+  async findOneByConfirmationToken(
+    prisma: BypassPrismaType,
+    token: string
+  ): Promise<UserEntity | null> {
     const user = await prisma.user.findFirst({
       where: {
         confirmationToken: token,
@@ -142,7 +145,7 @@ export class UserRepository {
     };
   }
 
-  async checkUniqueEmail(prisma: PrismaType, email: string, ownId?: string) {
+  async checkUniqueEmail(prisma: BypassPrismaType, email: string, ownId?: string) {
     const user = await prisma.user.findFirst({
       where: {
         email,
@@ -155,7 +158,7 @@ export class UserRepository {
     }
   }
 
-  async verified(prisma: PrismaType, entity: UserEntity): Promise<UserEntity> {
+  async verified(prisma: BypassPrismaType, entity: UserEntity): Promise<UserEntity> {
     const user = await prisma.user.update({
       where: {
         id: entity.id,
@@ -169,7 +172,7 @@ export class UserRepository {
     return UserEntity.Reconstruct<User, UserEntity>(user);
   }
 
-  async findOneByResetToken(prisma: PrismaType, token: string): Promise<UserEntity> {
+  async findOneByResetToken(prisma: BypassPrismaType, token: string): Promise<UserEntity> {
     const user = await prisma.user.findFirst({
       where: {
         resetPasswordToken: token,
@@ -184,7 +187,7 @@ export class UserRepository {
     return UserEntity.Reconstruct<User, UserEntity>(user);
   }
 
-  async updatePassword(prisma: PrismaType, entity: UserEntity): Promise<UserEntity> {
+  async updatePassword(prisma: BypassPrismaType, entity: UserEntity): Promise<UserEntity> {
     const updatedUser = await prisma.user.update({
       where: {
         id: entity.id,
@@ -198,7 +201,10 @@ export class UserRepository {
     return UserEntity.Reconstruct<User, UserEntity>(updatedUser);
   }
 
-  async updateResetPasswordToken(prisma: PrismaType, entity: UserEntity): Promise<UserEntity> {
+  async updateResetPasswordToken(
+    prisma: BypassPrismaType,
+    entity: UserEntity
+  ): Promise<UserEntity> {
     const user = await prisma.user.update({
       where: {
         id: entity.id,
@@ -224,7 +230,7 @@ export class UserRepository {
     return UserEntity.Reconstruct<User, UserEntity>(user);
   }
 
-  async updateProfile(prisma: PrismaType, user: UserEntity): Promise<UserEntity> {
+  async updateProfile(prisma: BypassPrismaType, user: UserEntity): Promise<UserEntity> {
     const updatedUser = await prisma.user.update({
       where: {
         id: user.id,

--- a/src/api/database/prisma/client.ts
+++ b/src/api/database/prisma/client.ts
@@ -36,12 +36,9 @@ const forProject = (projectId: string) => {
   );
 };
 
-// Access to tables with no row-level security
-export const prisma = new PrismaClient();
-export type PrismaType = PrismaClient | Prisma.TransactionClient;
-
 // Access to tables with row-level security
-export const projectPrisma = (projectId: string) => prisma.$extends(forProject(projectId));
+export const projectPrisma = (projectId: string) =>
+  new PrismaClient().$extends(forProject(projectId));
 export type ProjectPrismaClient = ReturnType<typeof projectPrisma>;
 export type ProjectTransactionClient = Parameters<
   Parameters<ProjectPrismaClient['$transaction']>[0]

--- a/src/api/routes/asset.router.ts
+++ b/src/api/routes/asset.router.ts
@@ -5,7 +5,7 @@ import { UnknownException } from '../../exceptions/storage/unknown.js';
 import { logger } from '../../utilities/logger.js';
 import { FileRepository } from '../data/file/file.repository.js';
 import { ProjectRepository } from '../data/project/project.repository.js';
-import { prisma, projectPrisma } from '../database/prisma/client.js';
+import { bypassPrisma, projectPrisma } from '../database/prisma/client.js';
 import { asyncHandler } from '../middlewares/asyncHandler.js';
 import { getDataUseCaseSchema } from '../useCases/asset/getData.schema.js';
 import { GetDataUseCase } from '../useCases/asset/getData.useCase.js';
@@ -29,7 +29,10 @@ router.get(
     });
     if (!validated.success) throw new InvalidPayloadException('bad_request', validated.error);
 
-    const projectUseCase = new GetProjectFromSubdomainUseCase(prisma, new ProjectRepository());
+    const projectUseCase = new GetProjectFromSubdomainUseCase(
+      bypassPrisma,
+      new ProjectRepository()
+    );
     const project = await projectUseCase.execute(validated.data.subdomain);
 
     const useCase = new GetDataUseCase(projectPrisma(project.id), new FileRepository());

--- a/src/api/routes/auth.router.ts
+++ b/src/api/routes/auth.router.ts
@@ -5,7 +5,7 @@ import { UnknownException } from '../../exceptions/storage/unknown.js';
 import { InvitationRepository } from '../data/invitation/invitation.repository.js';
 import { UserRepository } from '../data/user/user.repository.js';
 import { UserProjectRepository } from '../data/userProject/userProject.repository.js';
-import { bypassPrisma, prisma } from '../database/prisma/client.js';
+import { bypassPrisma } from '../database/prisma/client.js';
 import { asyncHandler } from '../middlewares/asyncHandler.js';
 import { SignUpMailService } from '../services/signUpMail.service.js';
 import { signInErrorUseCaseSchema } from '../useCases/auth/signInError.schema.js';
@@ -27,7 +27,6 @@ router.post(
     if (!validated.success) throw new InvalidPayloadException('bad_request', validated.error);
 
     const useCase = new SignUpUseCase(
-      prisma,
       bypassPrisma,
       new UserRepository(),
       new InvitationRepository(),
@@ -50,7 +49,7 @@ router.post(
     });
     if (!validated.success) throw new InvalidPayloadException('bad_request', validated.error);
 
-    const useCase = new VerifyUseCase(prisma, new UserRepository());
+    const useCase = new VerifyUseCase(bypassPrisma, new UserRepository());
     const me = await useCase.execute(validated.data);
 
     return res.json({

--- a/src/api/routes/me.router.ts
+++ b/src/api/routes/me.router.ts
@@ -3,7 +3,7 @@ import express, { Request, Response } from 'express';
 import { InvalidPayloadException } from '../../exceptions/invalidPayload.js';
 import { authConfig } from '../configs/auth.js';
 import { UserRepository } from '../data/user/user.repository.js';
-import { bypassPrisma, prisma } from '../database/prisma/client.js';
+import { bypassPrisma } from '../database/prisma/client.js';
 import { asyncHandler } from '../middlewares/asyncHandler.js';
 import { authenticatedUser } from '../middlewares/auth.js';
 import { ResetPasswordMailService } from '../services/resetPasswordMail.service.js';
@@ -39,7 +39,7 @@ router.get(
     });
     if (!validated.success) throw new InvalidPayloadException('bad_request', validated.error);
 
-    const useCase = new GetMyProfileUseCase(prisma, new UserRepository());
+    const useCase = new GetMyProfileUseCase(bypassPrisma, new UserRepository());
     const user = await useCase.execute(validated.data.userId);
 
     return res.json({ user });
@@ -73,7 +73,7 @@ router.patch(
     });
     if (!validated.success) throw new InvalidPayloadException('bad_request', validated.error);
 
-    const useCase = new UpdateProfileUseCase(prisma, new UserRepository());
+    const useCase = new UpdateProfileUseCase(bypassPrisma, new UserRepository());
     await useCase.execute(validated.data);
 
     res.status(204).end();
@@ -89,7 +89,7 @@ router.post(
     });
     if (!validated.success) throw new InvalidPayloadException('bad_request', validated.error);
 
-    const useCase = new ResetPasswordUseCase(prisma, new UserRepository());
+    const useCase = new ResetPasswordUseCase(bypassPrisma, new UserRepository());
     await useCase.execute(validated.data);
 
     res.status(204).end();
@@ -105,7 +105,7 @@ router.post(
     if (!validated.success) throw new InvalidPayloadException('bad_request', validated.error);
 
     const useCase = new ForgotPasswordUseCase(
-      prisma,
+      bypassPrisma,
       new UserRepository(),
       new ResetPasswordMailService()
     );

--- a/src/api/useCases/asset/getProjectFromSubdomain.useCase.ts
+++ b/src/api/useCases/asset/getProjectFromSubdomain.useCase.ts
@@ -1,10 +1,10 @@
 import { Project } from '@prisma/client';
 import { ProjectRepository } from '../../data/project/project.repository.js';
-import { PrismaType } from '../../database/prisma/client.js';
+import { BypassPrismaType } from '../../database/prisma/client.js';
 
 export class GetProjectFromSubdomainUseCase {
   constructor(
-    private readonly prisma: PrismaType,
+    private readonly prisma: BypassPrismaType,
     private readonly projectRepository: ProjectRepository
   ) {}
 

--- a/src/api/useCases/auth/verify.useCase.ts
+++ b/src/api/useCases/auth/verify.useCase.ts
@@ -1,13 +1,13 @@
-import { PrismaClient } from '@prisma/client';
+import { ConflictException } from '../../../exceptions/conflict.js';
 import { RecordNotFoundException } from '../../../exceptions/database/recordNotFound.js';
 import { Me } from '../../../types/index.js';
 import { UserRepository } from '../../data/user/user.repository.js';
+import { BypassPrismaClient } from '../../database/prisma/client.js';
 import { VerifyUseCaseSchemaType } from './verify.schema.js';
-import { ConflictException } from '../../../exceptions/conflict.js';
 
 export class VerifyUseCase {
   constructor(
-    private readonly prisma: PrismaClient,
+    private readonly prisma: BypassPrismaClient,
     private readonly userRepository: UserRepository
   ) {}
 

--- a/src/api/useCases/me/getMyProfile.useCase.ts
+++ b/src/api/useCases/me/getMyProfile.useCase.ts
@@ -1,10 +1,10 @@
 import { User } from '@prisma/client';
 import { UserRepository } from '../../data/user/user.repository.js';
-import { PrismaType } from '../../database/prisma/client.js';
+import { BypassPrismaType } from '../../database/prisma/client.js';
 
 export class GetMyProfileUseCase {
   constructor(
-    private readonly prisma: PrismaType,
+    private readonly prisma: BypassPrismaType,
     private readonly userRepository: UserRepository
   ) {}
 

--- a/src/api/useCases/me/updateProfile.useCase.ts
+++ b/src/api/useCases/me/updateProfile.useCase.ts
@@ -1,12 +1,12 @@
 import { User } from '@prisma/client';
 import { UserRepository } from '../../data/user/user.repository.js';
-import { PrismaType } from '../../database/prisma/client.js';
+import { BypassPrismaType } from '../../database/prisma/client.js';
 import { oneWayHash } from '../../utilities/oneWayHash.js';
 import { UpdateProfileUseCaseSchemaType } from './updateProfile.schema.js';
 
 export class UpdateProfileUseCase {
   constructor(
-    private readonly prisma: PrismaType,
+    private readonly prisma: BypassPrismaType,
     private readonly userRepository: UserRepository
   ) {}
 

--- a/src/api/useCases/user/forgotPassword.useCase.ts
+++ b/src/api/useCases/user/forgotPassword.useCase.ts
@@ -2,13 +2,13 @@ import { User } from '@prisma/client';
 import { InvalidCredentialsException } from '../../../exceptions/invalidCredentials.js';
 import { UnexpectedException } from '../../../exceptions/unexpected.js';
 import { UserRepository } from '../../data/user/user.repository.js';
-import { PrismaType } from '../../database/prisma/client.js';
+import { BypassPrismaType } from '../../database/prisma/client.js';
 import { ResetPasswordMailService } from '../../services/resetPasswordMail.service.js';
 import { ForgotPasswordUseCaseSchemaType } from './forgotPassword.schema.js';
 
 export class ForgotPasswordUseCase {
   constructor(
-    private readonly prisma: PrismaType,
+    private readonly prisma: BypassPrismaType,
     private readonly userRepository: UserRepository,
     private readonly mailService: ResetPasswordMailService
   ) {}

--- a/src/api/useCases/user/resetPassword.useCase.ts
+++ b/src/api/useCases/user/resetPassword.useCase.ts
@@ -1,11 +1,11 @@
 import { User } from '@prisma/client';
 import { UserRepository } from '../../data/user/user.repository.js';
-import { PrismaType } from '../../database/prisma/client.js';
+import { BypassPrismaType } from '../../database/prisma/client.js';
 import { ResetPasswordUseCaseSchemaType } from './resetPassword.schema.js';
 
 export class ResetPasswordUseCase {
   constructor(
-    private readonly prisma: PrismaType,
+    private readonly prisma: BypassPrismaType,
     private readonly userRepository: UserRepository
   ) {}
 


### PR DESCRIPTION
## What?
Merge prismaType into bypassPrismaType.

<!--
Write a brief description of your commitments.
-->

## Why?
`PrismaType` and `BypassPrismaType` are unified because they have the same purpose.

<!--
Write the need for the ticket.
-->