### PR TITLE
fix: local npm install fails

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+dotenv ./.env

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,11 +32,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      # - name: Create .npmrc file
-      #   run: |
-      #     echo "@tiptap-pro:registry=https://registry.tiptap.dev/" >> .npmrc
-      #     echo "//registry.tiptap.dev/:_authToken=${{ secrets.TIPTAP_PRO_TOKEN }}" >> .npmrc
-
       - name: install
         run: yarn install
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,6 +16,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    env:
+      TIPTAP_PRO_TOKEN: ${{ secrets.TIPTAP_PRO_TOKEN }}
 
     strategy:
       fail-fast: false
@@ -30,10 +32,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Create .npmrc file
-        run: |
-          echo "@tiptap-pro:registry=https://registry.tiptap.dev/" >> .npmrc
-          echo "//registry.tiptap.dev/:_authToken=${{ secrets.TIPTAP_PRO_TOKEN }}" >> .npmrc
+      # - name: Create .npmrc file
+      #   run: |
+      #     echo "@tiptap-pro:registry=https://registry.tiptap.dev/" >> .npmrc
+      #     echo "//registry.tiptap.dev/:_authToken=${{ secrets.TIPTAP_PRO_TOKEN }}" >> .npmrc
 
       - name: install
         run: yarn install

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,8 @@ jobs:
   integration:
     name: ${{ matrix.database }}
     runs-on: ubuntu-latest
+    env:
+      TIPTAP_PRO_TOKEN: ${{ secrets.TIPTAP_PRO_TOKEN }}
 
     strategy:
       fail-fast: false
@@ -24,11 +26,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Create .npmrc file
-        run: |
-          echo "@tiptap-pro:registry=https://registry.tiptap.dev/" >> .npmrc
-          echo "//registry.tiptap.dev/:_authToken=${{ secrets.TIPTAP_PRO_TOKEN }}" >> .npmrc
 
       - name: Yarn install
         run: yarn install

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 @tiptap-pro:registry=https://registry.tiptap.dev/
-//registry.tiptap.dev/:_authToken=$TIPTAP_PRO_TOKEN
+//registry.tiptap.dev/:_authToken=${TIPTAP_PRO_TOKEN}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ git clone git@github.com:collectionscms/collections.git
 cd collections
 cp .env.sample .env
 vi .env - make it your environment
+brew install direnv
+vi ~/.zshrc - add `eval "$(direnv hook zsh)"`
+source ~/.zshrc
+direnv allow .
 yarn install
 yarn db:refresh
 yarn dev


### PR DESCRIPTION
## What?
Read .env environment variable with direnv.

<!--
Write a brief description of your commitments.
-->

## Why?
Unable to read `TIPTAP_PRO_TOKEN` environment variable during install.

<!--
Write the need for the ticket.
-->