### PR TITLE
fix: don't convert to null at optional time

### DIFF
--- a/src/api/useCases/content/updateContent.useCase.ts
+++ b/src/api/useCases/content/updateContent.useCase.ts
@@ -24,14 +24,14 @@ export class UpdateContentUseCase {
     revision.updateContent({
       coverUrl: props.coverUrl,
       title: props.title,
-      subtitle: props.subtitle || null,
+      subtitle: props.subtitle,
       body: props.body,
       bodyJson: props.bodyJson,
       bodyHtml: props.bodyHtml,
       slug: props.slug,
       updatedById: props.userId,
-      metaTitle: props.metaTitle || null,
-      metaDescription: props.metaDescription || null,
+      metaTitle: props.metaTitle,
+      metaDescription: props.metaDescription,
     });
 
     const createdOrUpdatedRevision = await this.prisma.$transaction(async (tx) => {


### PR DESCRIPTION
## What?
Don't convert to null at optional time.

<!--
Write a brief description of your commitments.
-->

## Why?
If not included in post params, it will be overwritten with null.

<!--
Write the need for the ticket.
-->