### PR TITLE
fix: lock the prosemirror-view version

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,8 @@
     "typescript": "5.5.4"
   },
   "resolutions": {
-    "prosemirror-model": "1.22.3"
+    "prosemirror-model": "1.22.3",
+    "prosemirror-view": "1.34.2"
   },
   "keywords": [
     "cms",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9910,16 +9910,7 @@ prosemirror-transform@^1.10.0:
   dependencies:
     prosemirror-model "^1.21.0"
 
-prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.13.3, prosemirror-view@^1.27.0, prosemirror-view@^1.31.0:
-  version "1.33.9"
-  resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.33.9.tgz#0ed61ae42405cfc9799bde4db86badbb1ad99b08"
-  integrity sha512-xV1A0Vz9cIcEnwmMhKKFAOkfIp8XmJRnaZoPqNXrPS7EK5n11Ov8V76KhR0RsfQd/SIzmWY+bg+M44A2Lx/Nnw==
-  dependencies:
-    prosemirror-model "^1.20.0"
-    prosemirror-state "^1.0.0"
-    prosemirror-transform "^1.1.0"
-
-prosemirror-view@^1.33.10:
+prosemirror-view@1.34.2, prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.13.3, prosemirror-view@^1.27.0, prosemirror-view@^1.31.0, prosemirror-view@^1.33.10:
   version "1.34.2"
   resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.34.2.tgz#239a1766e46e364666e2b850855361929c4236df"
   integrity sha512-tPX/V2Xd70vrAGQ/V9CppJtPKnQyQMypJGlLylvdI94k6JaG+4P6fVmXPR1zc1eVTW0gq3c6zsfqwJKCRLaG9Q==


### PR DESCRIPTION
## What?
The following error occurs when clicking on the margins of an image.
Cannot read properties of undefined (reading 'localsInner')

<!--
Write a brief description of your commitments.
-->

## Why?
It is due to the existence of multiple prosemirror-view versions.
see: https://github.com/ueberdosis/tiptap/issues/3869

<!--
Write the need for the ticket.
-->

## How?
Refer to the following to fix the version of prosemirror-view.
https://github.com/ueberdosis/tiptap/issues/3869#issuecomment-1919863220

<!--
For user functionality additions, write the operating procedures.
For development modifications, write the configuration procedure.
For bug fixes, write the reproduction procedure.
-->

## Notes

<!--
Write commitment details.
-->
