### PR TITLE
feat: create apiKey when creating a project

### DIFF
--- a/src/api/persistence/apiKey/apiKey.repository.mock.ts
+++ b/src/api/persistence/apiKey/apiKey.repository.mock.ts
@@ -1,0 +1,9 @@
+import { ProjectPrismaType } from '../../database/prisma/client.js';
+import { ApiKeyEntity } from './apiKey.entity.js';
+import { ApiKeyRepository } from './apiKey.repository.js';
+
+export class InMemoryApiKeyRepository extends ApiKeyRepository {
+  async create(_prisma: ProjectPrismaType, entity: ApiKeyEntity): Promise<ApiKeyEntity> {
+    return entity;
+  }
+}

--- a/src/api/persistence/apiKeyPermission/apiKeyPermission.repository.mock.ts
+++ b/src/api/persistence/apiKeyPermission/apiKeyPermission.repository.mock.ts
@@ -1,0 +1,12 @@
+import { ProjectPrismaType } from '../../database/prisma/client.js';
+import { ApiKeyPermissionEntity } from './apiKeyPermission.entity.js';
+import { ApiKeyPermissionRepository } from './apiKeyPermission.repository.js';
+
+export class InMemoryApiKeyPermissionRepository extends ApiKeyPermissionRepository {
+  async createMany(
+    _prisma: ProjectPrismaType,
+    entities: ApiKeyPermissionEntity[]
+  ): Promise<ApiKeyPermissionEntity[]> {
+    return entities;
+  }
+}

--- a/src/api/persistence/project/project.repository.mock.ts
+++ b/src/api/persistence/project/project.repository.mock.ts
@@ -1,0 +1,17 @@
+import { BypassPrismaType, ProjectPrismaType } from '../../database/prisma/client.js';
+import { buildProjectEntity } from './project.entity.fixture.js';
+import { ProjectEntity } from './project.entity.js';
+import { ProjectRepository } from './project.repository.js';
+
+export class InMemoryProjectRepository extends ProjectRepository {
+  async findOneBySubdomain(
+    _prisma: BypassPrismaType,
+    subdomain: string
+  ): Promise<ProjectEntity | null> {
+    return buildProjectEntity({ subdomain });
+  }
+
+  async create(_prisma: ProjectPrismaType, entity: ProjectEntity): Promise<ProjectEntity> {
+    return entity;
+  }
+}

--- a/src/api/persistence/role/role.entity.ts
+++ b/src/api/persistence/role/role.entity.ts
@@ -8,17 +8,19 @@ export class RoleEntity extends PrismaBaseEntity<Role> {
     projectId,
     name,
     description,
+    isAdmin,
   }: {
     projectId: string;
     name: string;
     description: string | null;
+    isAdmin?: boolean;
   }): RoleEntity {
     return new RoleEntity({
       id: v4(),
       projectId,
       name,
       description,
-      isAdmin: false,
+      isAdmin: isAdmin || false,
       createdAt: new Date(),
       updatedAt: new Date(),
     });
@@ -45,10 +47,6 @@ export class RoleEntity extends PrismaBaseEntity<Role> {
   get isAdmin(): boolean {
     return this.props.isAdmin;
   }
-
-  changeToAdmin = () => {
-    this.props.isAdmin = true;
-  };
 
   update = (params: { name: string; description: string | null }) => {
     this.props.name = params.name;

--- a/src/api/persistence/role/role.repository.mock.ts
+++ b/src/api/persistence/role/role.repository.mock.ts
@@ -1,0 +1,9 @@
+import { ProjectPrismaType } from '../../database/prisma/client.js';
+import { RoleEntity } from './role.entity.js';
+import { RoleRepository } from './role.repository.js';
+
+export class InMemoryRoleRepository extends RoleRepository {
+  async create(_prisma: ProjectPrismaType, entity: RoleEntity): Promise<RoleEntity> {
+    return entity;
+  }
+}

--- a/src/api/persistence/userProject/userProject.repository.mock.ts
+++ b/src/api/persistence/userProject/userProject.repository.mock.ts
@@ -7,6 +7,7 @@ import { buildRoleEntity } from '../role/role.entity.fixture.js';
 import { RoleEntity } from '../role/role.entity.js';
 import { buildUserEntity } from '../user/user.entity.fixture.js';
 import { UserEntity } from '../user/user.entity.js';
+import { UserProjectEntity } from './userProject.entity.js';
 import { UserProjectRepository } from './userProject.repository.js';
 
 export class InMemoryUserProjectRepository extends UserProjectRepository {
@@ -27,5 +28,9 @@ export class InMemoryUserProjectRepository extends UserProjectRepository {
       role: buildRoleEntity(),
       permissions: [buildPermissionEntity()],
     };
+  }
+
+  async create(_prisma: ProjectPrismaType, entity: UserProjectEntity): Promise<UserProjectEntity> {
+    return entity;
   }
 }

--- a/src/api/routes/project.router.ts
+++ b/src/api/routes/project.router.ts
@@ -4,17 +4,19 @@ import { bypassPrisma, projectPrisma } from '../database/prisma/client.js';
 import { asyncHandler } from '../middlewares/asyncHandler.js';
 import { authenticatedUser } from '../middlewares/auth.js';
 import { validateAccess } from '../middlewares/validateAccess.js';
+import { ApiKeyRepository } from '../persistence/apiKey/apiKey.repository.js';
+import { ApiKeyPermissionRepository } from '../persistence/apiKeyPermission/apiKeyPermission.repository.js';
 import { ProjectRepository } from '../persistence/project/project.repository.js';
 import { RoleRepository } from '../persistence/role/role.repository.js';
 import { UserProjectRepository } from '../persistence/userProject/userProject.repository.js';
-import { createProjectUseCaseSchema } from '../useCases/project/createProject.useCase.schema.js';
 import { CreateProjectUseCase } from '../useCases/project/createProject.useCase.js';
-import { getMyProjectUseCaseSchema } from '../useCases/project/getMyProject.useCase.schema.js';
+import { createProjectUseCaseSchema } from '../useCases/project/createProject.useCase.schema.js';
 import { GetMyProjectUseCase } from '../useCases/project/getMyProject.useCase.js';
-import { getSubdomainAvailabilityUseCaseSchema } from '../useCases/project/getSubdomainAvailability.useCase.schema.js';
+import { getMyProjectUseCaseSchema } from '../useCases/project/getMyProject.useCase.schema.js';
 import { GetSubdomainAvailabilityUseCase } from '../useCases/project/getSubdomainAvailability.useCase.js';
-import { updateProjectUseCaseSchema } from '../useCases/project/updateProject.useCase.schema.js';
+import { getSubdomainAvailabilityUseCaseSchema } from '../useCases/project/getSubdomainAvailability.useCase.schema.js';
 import { UpdateProjectUseCase } from '../useCases/project/updateProject.useCase.js';
+import { updateProjectUseCaseSchema } from '../useCases/project/updateProject.useCase.schema.js';
 
 const router = express.Router();
 
@@ -70,7 +72,9 @@ router.post(
       bypassPrisma,
       new ProjectRepository(),
       new UserProjectRepository(),
-      new RoleRepository()
+      new RoleRepository(),
+      new ApiKeyRepository(),
+      new ApiKeyPermissionRepository()
     );
     const project = await useCase.execute(validated.data);
 

--- a/src/api/useCases/content/getPublishedContent.useCase.test.ts
+++ b/src/api/useCases/content/getPublishedContent.useCase.test.ts
@@ -43,7 +43,9 @@ describe('GetPublishedContentUseCase', () => {
           projectId,
           slug: 'slug',
         })
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({
+        code: 'record_not_found',
+      });
     });
   });
 
@@ -72,7 +74,9 @@ describe('GetPublishedContentUseCase', () => {
           slug: 'slug',
           draftKey: 'draftKey',
         })
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({
+        code: 'record_not_found',
+      });
     });
 
     it('should throw an error if the draft key does not match the draft content', async () => {
@@ -91,7 +95,9 @@ describe('GetPublishedContentUseCase', () => {
           slug: 'slug',
           draftKey: 'draftKey',
         })
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({
+        code: 'record_not_found',
+      });
     });
   });
 });

--- a/src/api/useCases/project/createProject.useCase.test.ts
+++ b/src/api/useCases/project/createProject.useCase.test.ts
@@ -1,0 +1,80 @@
+/* eslint-disable max-len */
+import { expect, jest } from '@jest/globals';
+import { v4 } from 'uuid';
+import { bypassPrisma } from '../../database/prisma/client.js';
+import { InMemoryApiKeyRepository } from '../../persistence/apiKey/apiKey.repository.mock.js';
+import { InMemoryApiKeyPermissionRepository } from '../../persistence/apiKeyPermission/apiKeyPermission.repository.mock.js';
+import { InMemoryProjectRepository } from '../../persistence/project/project.repository.mock.js';
+import { InMemoryRoleRepository } from '../../persistence/role/role.repository.mock.js';
+import { InMemoryUserProjectRepository } from '../../persistence/userProject/userProject.repository.mock.js';
+import { CreateProjectUseCase } from './createProject.useCase';
+
+describe('CreateProject', () => {
+  const userId = v4();
+  const reservedSubdomain = 'app';
+
+  const prisma = bypassPrisma;
+  jest.spyOn(prisma, '$transaction').mockImplementation(async (fn) => {
+    return await fn(prisma);
+  });
+
+  const useCase = new CreateProjectUseCase(
+    prisma,
+    new InMemoryProjectRepository(),
+    new InMemoryUserProjectRepository(),
+    new InMemoryRoleRepository(),
+    new InMemoryApiKeyRepository(),
+    new InMemoryApiKeyPermissionRepository()
+  );
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when the subdomain is not reserved', () => {
+    it('should create a project', async () => {
+      const result = await useCase.execute({
+        userId,
+        name: 'project name',
+        sourceLanguage: 'en-us',
+        subdomain: 'new-subdomain',
+      });
+
+      expect(result).toMatchObject({
+        name: 'project name',
+        sourceLanguage: 'en-us',
+        subdomain: 'new-subdomain',
+      });
+    });
+
+    it('should throw an error if project already exists', async () => {
+      await expect(
+        useCase.execute({
+          userId,
+          name: 'project name',
+          sourceLanguage: 'en-us',
+          subdomain: reservedSubdomain,
+        })
+      ).rejects.toMatchObject({
+        code: 'already_registered_project_id',
+      });
+    });
+  });
+
+  describe('when the subdomain is reserved', () => {
+    jest.spyOn(InMemoryProjectRepository.prototype, 'findOneBySubdomain').mockResolvedValue(null);
+
+    it('should throw an error if the subdomain is a reserved subdomain', async () => {
+      await expect(
+        useCase.execute({
+          userId,
+          name: 'project name',
+          sourceLanguage: 'en-us',
+          subdomain: reservedSubdomain,
+        })
+      ).rejects.toMatchObject({
+        code: 'already_registered_project_id',
+      });
+    });
+  });
+});

--- a/src/api/useCases/project/createProject.useCase.ts
+++ b/src/api/useCases/project/createProject.useCase.ts
@@ -43,10 +43,10 @@ export class CreateProjectUseCase {
       projectId: projectEntity.id,
       name: t('seed.role.admin'),
       description: t('seed.role.admin_description'),
+      isAdmin: true,
     });
-    roleEntity.changeToAdmin();
 
-    const entity = UserProjectEntity.Construct({
+    const userProjectEntity = UserProjectEntity.Construct({
       userId: userId,
       projectId: projectEntity.id,
       roleId: roleEntity.id,
@@ -55,7 +55,7 @@ export class CreateProjectUseCase {
     const createdProject = await this.prisma.$transaction(async (tx) => {
       const result = await this.projectRepository.create(tx, projectEntity);
       await this.roleRepository.create(tx, roleEntity);
-      await this.userProjectRepository.create(tx, entity);
+      await this.userProjectRepository.create(tx, userProjectEntity);
 
       return result;
     });

--- a/src/api/useCases/project/createProject.useCase.ts
+++ b/src/api/useCases/project/createProject.useCase.ts
@@ -3,6 +3,10 @@ import { env } from '../../../env.js';
 import { RecordNotUniqueException } from '../../../exceptions/database/recordNotUnique.js';
 import i18n from '../../../lang/translations/config.js';
 import { BypassPrismaClient } from '../../database/prisma/client.js';
+import { ApiKeyEntity } from '../../persistence/apiKey/apiKey.entity.js';
+import { ApiKeyRepository } from '../../persistence/apiKey/apiKey.repository.js';
+import { ApiKeyPermissionEntity } from '../../persistence/apiKeyPermission/apiKeyPermission.entity.js';
+import { ApiKeyPermissionRepository } from '../../persistence/apiKeyPermission/apiKeyPermission.repository.js';
 import { ProjectEntity } from '../../persistence/project/project.entity.js';
 import { ProjectRepository } from '../../persistence/project/project.repository.js';
 import { RoleEntity } from '../../persistence/role/role.entity.js';
@@ -16,7 +20,9 @@ export class CreateProjectUseCase {
     private readonly prisma: BypassPrismaClient,
     private readonly projectRepository: ProjectRepository,
     private readonly userProjectRepository: UserProjectRepository,
-    private readonly roleRepository: RoleRepository
+    private readonly roleRepository: RoleRepository,
+    private readonly apiKeyRepository: ApiKeyRepository,
+    private readonly apiKeyPermissionRepository: ApiKeyPermissionRepository
   ) {}
 
   async execute({
@@ -52,10 +58,24 @@ export class CreateProjectUseCase {
       roleId: roleEntity.id,
     });
 
+    const apiKeyEntity = ApiKeyEntity.Construct({
+      name: 'default',
+      projectId: projectEntity.id,
+      createdById: userId,
+    });
+
+    const permissionEntity = ApiKeyPermissionEntity.Construct({
+      apiKeyId: apiKeyEntity.id,
+      projectId: projectEntity.id,
+      permissionAction: 'readPublishedPost',
+    });
+
     const createdProject = await this.prisma.$transaction(async (tx) => {
       const result = await this.projectRepository.create(tx, projectEntity);
       await this.roleRepository.create(tx, roleEntity);
       await this.userProjectRepository.create(tx, userProjectEntity);
+      await this.apiKeyRepository.create(tx, apiKeyEntity);
+      await this.apiKeyPermissionRepository.createMany(tx, [permissionEntity]);
 
       return result;
     });

--- a/src/api/useCases/review/closeReview.useCase.test.ts
+++ b/src/api/useCases/review/closeReview.useCase.test.ts
@@ -60,7 +60,9 @@ describe('CloseReviewUseCase', () => {
 
       await expect(
         useCase.execute({ projectId, userId, reviewId, isAdmin, permissions: [] }, hasReadAllReview)
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({
+        code: 'record_not_found',
+      });
     });
 
     it('should throw an error if the content revision not found', async () => {
@@ -81,7 +83,9 @@ describe('CloseReviewUseCase', () => {
 
       await expect(
         useCase.execute({ projectId, userId, reviewId, isAdmin, permissions: [] }, hasReadAllReview)
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({
+        code: 'record_not_found',
+      });
     });
   });
 
@@ -119,7 +123,9 @@ describe('CloseReviewUseCase', () => {
 
       await expect(
         useCase.execute({ projectId, userId, reviewId, isAdmin, permissions: [] }, hasReadAllReview)
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({
+        code: 'record_not_found',
+      });
     });
 
     it('should throw an error if the content revision not found', async () => {
@@ -140,7 +146,9 @@ describe('CloseReviewUseCase', () => {
 
       await expect(
         useCase.execute({ projectId, userId, reviewId, isAdmin, permissions: [] }, hasReadAllReview)
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({
+        code: 'record_not_found',
+      });
     });
   });
 });

--- a/src/api/useCases/tag/getTagPublishedListContents.useCase.test.ts
+++ b/src/api/useCases/tag/getTagPublishedListContents.useCase.test.ts
@@ -61,6 +61,8 @@ describe('GetTagPublishedListContentsUseCase', () => {
         tagName: 'tag',
         projectId,
       })
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({
+      code: 'record_not_found',
+    });
   });
 });

--- a/src/api/useCases/user/getUserPublishedListContents.useCase.test.ts
+++ b/src/api/useCases/user/getUserPublishedListContents.useCase.test.ts
@@ -31,6 +31,8 @@ describe('GetUserPublishedListContentsUseCase', () => {
       .spyOn(InMemoryUserProjectRepository.prototype, 'findOneWithRoleByUserId')
       .mockResolvedValue(null);
 
-    await expect(useCase.execute({ projectId, id: v4() })).rejects.toThrow();
+    await expect(useCase.execute({ projectId, id: v4() })).rejects.toMatchObject({
+      code: 'record_not_found',
+    });
   });
 });


### PR DESCRIPTION
## What?
Create apiKey when creating a project.

<!--
Write a brief description of your commitments.
-->

## Why?
The api key improves the experience in article writing.

<!--
Write the need for the ticket.
-->

## How?
When a new project is created, an api key named `default` is created.

<!--
For user functionality additions, write the operating procedures.
For development modifications, write the configuration procedure.
For bug fixes, write the reproduction procedure.
-->

## Notes

<!--
Write commitment details.
-->
