### PR TITLE
refactor: refactoring the API so that content can be retrieved even with id

### DIFF
--- a/docs/data/api.yaml
+++ b/docs/data/api.yaml
@@ -53,13 +53,13 @@ paths:
   ## #####################################
   ## Contents
   ## #####################################
-  /api/v1/contents/{slug}:
+  /api/v1/contents/{identifier}:
     get:
       summary: Get content
       description: Returns a content with published status.
       operationId: getContent
       parameters:
-        - $ref: '#/components/parameters/slug'
+        - $ref: '#/components/parameters/identifier'
         - $ref: '#/components/parameters/draftKey'
       responses:
         '200':
@@ -141,11 +141,17 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/id'
-    slug:
-      name: slug
+    identifier:
+      name: identifier
       in: path
-      description: Slug
-      example: 'my-first-post'
+      description: Id or Slug
+      examples:
+        id:
+          summary: Id
+          value: 'a8c4891c-6bc0-4f58-81c6-5e89bb572d4c'
+        slug:
+          summary: Slug
+          value: 'my-first-post'
       required: true
       schema:
         type: string

--- a/src/admin/pages/Post/Edit/PostHeader/PublishSettings/index.tsx
+++ b/src/admin/pages/Post/Edit/PostHeader/PublishSettings/index.tsx
@@ -80,18 +80,18 @@ export const PublishSettings: React.FC<Props> = ({ open, content, onClose }) => 
     formState: { errors },
   } = useForm<FormValues>({
     defaultValues: {
-      status: hasPermission('publishPost') ? 'published' : 'review',
+      status: '',
       comment: '',
     },
     resolver: yupResolver(editContentValidator()),
   });
 
   useEffect(() => {
-    const status = content.status.isPublished
-      ? hasPermission('publishPost')
-        ? 'published'
-        : 'archived'
-      : 'review';
+    const status = hasPermission('publishPost')
+      ? 'published'
+      : content.status.isPublished
+        ? 'archived'
+        : 'review';
     setValue('status', status);
   }, [content.status.currentStatus]);
 

--- a/src/api/persistence/content/content.repository.mock.ts
+++ b/src/api/persistence/content/content.repository.mock.ts
@@ -18,6 +18,18 @@ export class InMemoryContentRepository extends ContentRepository {
     };
   }
 
+  async findOneByIdOrSlug(
+    _prisma: ProjectPrismaType,
+    identifier: string
+  ): Promise<{ content: ContentEntity; createdBy: UserEntity } | null> {
+    return {
+      content: buildContentEntity({
+        id: identifier,
+      }),
+      createdBy: buildUserEntity(),
+    };
+  }
+
   async findPublishedContentsByCreatedById(
     _prisma: ProjectPrismaType,
     userId: string

--- a/src/api/persistence/content/content.repository.ts
+++ b/src/api/persistence/content/content.repository.ts
@@ -43,6 +43,36 @@ export class ContentRepository {
     };
   }
 
+  async findOneByIdOrSlug(
+    prisma: ProjectPrismaType,
+    identifier: string
+  ): Promise<{ content: ContentEntity; createdBy: UserEntity } | null> {
+    const record = await prisma.content.findFirst({
+      where: {
+        OR: [
+          {
+            id: identifier,
+          },
+          {
+            slug: identifier,
+          },
+        ],
+      },
+      include: {
+        createdBy: true,
+      },
+    });
+
+    if (!record) {
+      return null;
+    }
+
+    return {
+      content: ContentEntity.Reconstruct<Content, ContentEntity>(record),
+      createdBy: UserEntity.Reconstruct<User, UserEntity>(record.createdBy),
+    };
+  }
+
   async findOneWithRevisionsById(
     prisma: ProjectPrismaType,
     id: string

--- a/src/api/persistence/contentRevision/contentRevision.repository.mock.ts
+++ b/src/api/persistence/contentRevision/contentRevision.repository.mock.ts
@@ -18,6 +18,18 @@ export class InMemoryContentRevisionRepository extends ContentRevisionRepository
     };
   }
 
+  async findLatestOneByContentIdOrSlug(
+    _prisma: ProjectPrismaType,
+    identifier: string
+  ): Promise<{ contentRevision: ContentRevisionEntity; createdBy: UserEntity } | null> {
+    return {
+      contentRevision: buildContentRevisionEntity({
+        contentId: identifier,
+      }),
+      createdBy: buildUserEntity(),
+    };
+  }
+
   async findLatestOneByContentId(
     _prisma: ProjectPrismaType,
     contentId: string

--- a/src/api/persistence/contentRevision/contentRevision.repository.ts
+++ b/src/api/persistence/contentRevision/contentRevision.repository.ts
@@ -63,7 +63,39 @@ export class ContentRevisionRepository {
     const record = await prisma.contentRevision.findFirst({
       where: {
         slug,
-        deletedAt: null,
+      },
+      orderBy: {
+        version: 'desc',
+      },
+      include: {
+        createdBy: true,
+      },
+    });
+
+    if (!record) return null;
+
+    return {
+      contentRevision: ContentRevisionEntity.Reconstruct<ContentRevision, ContentRevisionEntity>(
+        record
+      ),
+      createdBy: UserEntity.Reconstruct<User, UserEntity>(record.createdBy),
+    };
+  }
+
+  async findLatestOneByContentIdOrSlug(
+    prisma: ProjectPrismaType,
+    identifier: string
+  ): Promise<{ contentRevision: ContentRevisionEntity; createdBy: UserEntity } | null> {
+    const record = await prisma.contentRevision.findFirst({
+      where: {
+        OR: [
+          {
+            contentId: identifier,
+          },
+          {
+            slug: identifier,
+          },
+        ],
       },
       orderBy: {
         version: 'desc',

--- a/src/api/routes/public/v1/content.router.ts
+++ b/src/api/routes/public/v1/content.router.ts
@@ -13,14 +13,14 @@ import { getPublishedContentUseCaseSchema } from '../../../useCases/content/getP
 const router = express.Router();
 
 router.get(
-  '/contents/:slug',
+  '/contents/:identifier',
   authenticatedUser,
   validateAccess(['readPublishedPost']),
   asyncHandler(async (req: Request, res: Response) => {
     const validated = getPublishedContentUseCaseSchema.safeParse({
       projectId: res.projectRole?.id,
       language: req.query?.language,
-      slug: req.params.slug,
+      identifier: req.params.identifier,
       draftKey: req.query?.draftKey,
     });
     if (!validated.success) throw new InvalidPayloadException('bad_request', validated.error);

--- a/src/api/useCases/content/getPublishedContent.useCase.schema.ts
+++ b/src/api/useCases/content/getPublishedContent.useCase.schema.ts
@@ -4,7 +4,7 @@ import { IsoLanguageCode } from '../../../constants/languages.js';
 export const getPublishedContentUseCaseSchema = z.object({
   projectId: z.string().uuid(),
   language: z.nativeEnum(IsoLanguageCode).optional(),
-  slug: z.string(),
+  identifier: z.string(),
   draftKey: z.string().optional(),
 });
 export type GetPublishedContentUseCaseSchemaType = z.infer<typeof getPublishedContentUseCaseSchema>;

--- a/src/api/useCases/content/getPublishedContent.useCase.test.ts
+++ b/src/api/useCases/content/getPublishedContent.useCase.test.ts
@@ -26,11 +26,24 @@ describe('GetPublishedContentUseCase', () => {
     it('should return published content by slug', async () => {
       const record = await useCase.execute({
         projectId,
-        slug: 'slug',
+        identifier: 'slug',
       });
 
       expect(record).toMatchObject({
         slug: 'slug',
+        status: 'published',
+      });
+    });
+
+    it('should return published content by id', async () => {
+      const id = v4();
+      const record = await useCase.execute({
+        projectId,
+        identifier: id,
+      });
+
+      expect(record).toMatchObject({
+        id,
         status: 'published',
       });
     });
@@ -41,7 +54,7 @@ describe('GetPublishedContentUseCase', () => {
       await expect(
         useCase.execute({
           projectId,
-          slug: 'slug',
+          identifier: 'slug',
         })
       ).rejects.toMatchObject({
         code: 'record_not_found',
@@ -53,12 +66,26 @@ describe('GetPublishedContentUseCase', () => {
     it('should return draft content by slug and draft key', async () => {
       const record = await useCase.execute({
         projectId,
-        slug: 'slug',
+        identifier: 'slug',
         draftKey: 'draftKey',
       });
 
       expect(record).toMatchObject({
         slug: 'slug',
+        status: 'draft',
+      });
+    });
+
+    it('should return draft content by id and draft key', async () => {
+      const contentId = v4();
+      const record = await useCase.execute({
+        projectId,
+        identifier: contentId,
+        draftKey: 'draftKey',
+      });
+
+      expect(record).toMatchObject({
+        id: contentId,
         status: 'draft',
       });
     });
@@ -71,7 +98,7 @@ describe('GetPublishedContentUseCase', () => {
       await expect(
         useCase.execute({
           projectId,
-          slug: 'slug',
+          identifier: 'slug',
           draftKey: 'draftKey',
         })
       ).rejects.toMatchObject({
@@ -92,7 +119,7 @@ describe('GetPublishedContentUseCase', () => {
       await expect(
         useCase.execute({
           projectId,
-          slug: 'slug',
+          identifier: 'slug',
           draftKey: 'draftKey',
         })
       ).rejects.toMatchObject({


### PR DESCRIPTION
## What?
Refactoring the API so that content can be retrieved even with id.

<!--
Write a brief description of your commitments.
-->

## Why?
Guess from sentry error log. Indeed, it is hard to understand intuitively.

<!--
Write the need for the ticket.
-->

## How?
Change path `/contents/:slug` to `/contents/:identifier`.

<!--
For user functionality additions, write the operating procedures.
For development modifications, write the configuration procedure.
For bug fixes, write the reproduction procedure.
-->

## Notes

<!--
Write commitment details.
-->
