### PR TITLE
refactor: reuse empty post / content

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,10 +6,11 @@
   "extends": ["plugin:react/recommended", "prettier"],
   "overrides": [
     {
-      "files": ["test/**/*.test.ts"],
+      "files": ["*.test.ts"],
       "rules": {
         "no-restricted-syntax": ["error", "ForInStatement"],
-        "no-await-in-loop": 0
+        "no-await-in-loop": 0,
+        "max-len": "off"
       }
     }
   ],

--- a/prisma/migrations/20250125233939_add_is_init_to_post/migration.sql
+++ b/prisma/migrations/20250125233939_add_is_init_to_post/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Content" ALTER COLUMN "draftKey" SET DEFAULT substring(md5(random()::text), 1, 10);
+
+-- AlterTable
+ALTER TABLE "ContentRevision" ALTER COLUMN "draftKey" SET DEFAULT substring(md5(random()::text), 1, 10);
+
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "isInit" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/migrations/20250125233939_add_is_init_to_post/migration.sql
+++ b/prisma/migrations/20250125233939_add_is_init_to_post/migration.sql
@@ -1,8 +1,0 @@
--- AlterTable
-ALTER TABLE "Content" ALTER COLUMN "draftKey" SET DEFAULT substring(md5(random()::text), 1, 10);
-
--- AlterTable
-ALTER TABLE "ContentRevision" ALTER COLUMN "draftKey" SET DEFAULT substring(md5(random()::text), 1, 10);
-
--- AlterTable
-ALTER TABLE "Post" ADD COLUMN     "isInit" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/migrations/20250126001539_delete_default_for_draft_key/migration.sql
+++ b/prisma/migrations/20250126001539_delete_default_for_draft_key/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Content" ALTER COLUMN "draftKey" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "ContentRevision" ALTER COLUMN "draftKey" DROP DEFAULT;

--- a/prisma/migrations/20250126001605_add_is_init_to_post/migration.sql
+++ b/prisma/migrations/20250126001605_add_is_init_to_post/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "isInit" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -211,7 +211,7 @@ model Content {
   language             String                @db.VarChar(255)
   status               String                @db.VarChar(255)
   currentVersion       Int                   @default(1)
-  draftKey             String                @default(dbgenerated("substring(md5(random()::text), 1, 10)")) @db.VarChar(255)
+  draftKey             String                @db.VarChar(255)
   publishedAt          DateTime?             @db.Timestamptz(6)
   deletedAt            DateTime?             @db.Timestamptz(6)
   createdById          String                @db.Uuid
@@ -248,7 +248,7 @@ model ContentRevision {
   language        String    @db.VarChar(255)
   status          String    @db.VarChar(255)
   version         Int       @default(1)
-  draftKey        String    @default(dbgenerated("substring(md5(random()::text), 1, 10)")) @db.VarChar(255)
+  draftKey        String    @db.VarChar(255)
   publishedAt     DateTime? @db.Timestamptz(6)
   deletedAt       DateTime? @db.Timestamptz(6)
   createdById     String    @db.Uuid

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -166,6 +166,7 @@ model File {
 model Post {
   id               String            @id @db.Uuid
   projectId        String            @default(dbgenerated("(current_setting('app.current_project_id'::text))::uuid")) @db.Uuid
+  isInit           Boolean           @default(false)
   createdById      String            @db.Uuid
   createdAt        DateTime          @default(now()) @db.Timestamptz(6)
   updatedAt        DateTime          @updatedAt @db.Timestamptz(6)

--- a/src/api/persistence/post/post.entity.fixture.ts
+++ b/src/api/persistence/post/post.entity.fixture.ts
@@ -1,0 +1,21 @@
+import { Post } from '@prisma/client';
+import { v4 } from 'uuid';
+import { PostEntity } from './post.entity.js';
+
+const defaultValue = {
+  id: v4(),
+  projectId: v4(),
+  createdById: v4(),
+  isInit: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+export const buildPostEntity = <K extends keyof Post>(props?: {
+  [key in K]: Post[key];
+}): PostEntity => {
+  return PostEntity.Reconstruct<Post, PostEntity>({
+    ...defaultValue,
+    ...props,
+  });
+};

--- a/src/api/persistence/post/post.entity.ts
+++ b/src/api/persistence/post/post.entity.ts
@@ -66,6 +66,14 @@ export class PostEntity extends PrismaBaseEntity<Post> {
     return this.props.projectId;
   }
 
+  get isInit(): boolean {
+    return this.props.isInit;
+  }
+
+  unsetInit() {
+    this.props.isInit = false;
+  }
+
   /**
    * Convert entity to source language post item response
    * @param sourceLanguage

--- a/src/api/persistence/post/post.entity.ts
+++ b/src/api/persistence/post/post.entity.ts
@@ -28,6 +28,7 @@ export class PostEntity extends PrismaBaseEntity<Post> {
     const post = new PostEntity({
       id: postId,
       projectId,
+      isInit: true,
       createdById,
       createdAt: new Date(),
       updatedAt: new Date(),

--- a/src/api/persistence/post/post.repository.mock.ts
+++ b/src/api/persistence/post/post.repository.mock.ts
@@ -1,4 +1,8 @@
 import { ProjectPrismaType } from '../../database/prisma/client.js';
+import { buildContentEntity } from '../content/content.entity.fixture.js';
+import { ContentEntity } from '../content/content.entity.js';
+import { buildContentRevisionEntity } from '../contentRevision/contentRevision.entity.fixture.js';
+import { ContentRevisionEntity } from '../contentRevision/contentRevision.entity.js';
 import { buildPostEntity } from './post.entity.fixture.js';
 import { PostEntity } from './post.entity.js';
 import { PostRepository } from './post.repository.js';
@@ -8,6 +12,20 @@ export class InMemoryPostRepository extends PostRepository {
     return buildPostEntity({
       id,
     });
+  }
+
+  async findOneByIsInit(_prisma: ProjectPrismaType): Promise<{
+    post: PostEntity;
+    content: ContentEntity;
+    revision: ContentRevisionEntity;
+  } | null> {
+    return {
+      post: buildPostEntity({
+        isInit: false,
+      }),
+      content: buildContentEntity({}),
+      revision: buildContentRevisionEntity({}),
+    };
   }
 
   async update(_prisma: ProjectPrismaType, post: PostEntity): Promise<PostEntity> {

--- a/src/api/persistence/post/post.repository.mock.ts
+++ b/src/api/persistence/post/post.repository.mock.ts
@@ -1,0 +1,16 @@
+import { ProjectPrismaType } from '../../database/prisma/client.js';
+import { buildPostEntity } from './post.entity.fixture.js';
+import { PostEntity } from './post.entity.js';
+import { PostRepository } from './post.repository.js';
+
+export class InMemoryPostRepository extends PostRepository {
+  async findOneById(_prisma: ProjectPrismaType, id: string): Promise<PostEntity | null> {
+    return buildPostEntity({
+      id,
+    });
+  }
+
+  async update(_prisma: ProjectPrismaType, post: PostEntity): Promise<PostEntity> {
+    return post;
+  }
+}

--- a/src/api/persistence/post/post.repository.ts
+++ b/src/api/persistence/post/post.repository.ts
@@ -59,6 +59,32 @@ export class PostRepository {
     };
   }
 
+  async findOneByIsInit(prisma: ProjectPrismaType): Promise<{
+    post: PostEntity;
+    content: ContentEntity;
+    revision: ContentRevisionEntity;
+  } | null> {
+    const record = await prisma.post.findFirst({
+      where: {
+        isInit: true,
+      },
+      include: {
+        contents: true,
+        contentRevisions: true,
+      },
+    });
+
+    return record
+      ? {
+          post: PostEntity.Reconstruct<Post, PostEntity>(record),
+          content: ContentEntity.Reconstruct<Content, ContentEntity>(record.contents[0]),
+          revision: ContentRevisionEntity.Reconstruct<ContentRevision, ContentRevisionEntity>(
+            record.contentRevisions[0]
+          ),
+        }
+      : null;
+  }
+
   async findMany(
     prisma: ProjectPrismaType,
     options?: {
@@ -92,6 +118,7 @@ export class PostRepository {
         },
       },
       where: {
+        isInit: false,
         createdById: options?.userId,
       },
       orderBy: {

--- a/src/api/persistence/post/post.repository.ts
+++ b/src/api/persistence/post/post.repository.ts
@@ -7,6 +7,13 @@ import { UserEntity } from '../user/user.entity.js';
 import { PostEntity } from './post.entity.js';
 
 export class PostRepository {
+  async findOneById(prisma: ProjectPrismaType, id: string): Promise<PostEntity | null> {
+    const record = await prisma.post.findUnique({
+      where: { id },
+    });
+    return record ? PostEntity.Reconstruct<Post, PostEntity>(record) : null;
+  }
+
   async findOnePublishedById(
     prisma: ProjectPrismaType,
     id: string
@@ -194,6 +201,17 @@ export class PostRepository {
     postEntity.beforeInsertValidate();
 
     const record = await prisma.post.create({
+      data: postEntity.toPersistence(),
+    });
+
+    return PostEntity.Reconstruct<Post, PostEntity>(record);
+  }
+
+  async update(prisma: ProjectPrismaType, postEntity: PostEntity): Promise<PostEntity> {
+    postEntity.beforeUpdateValidate();
+
+    const record = await prisma.post.update({
+      where: { id: postEntity.id },
       data: postEntity.toPersistence(),
     });
 

--- a/src/api/persistence/project/project.repository.mock.ts
+++ b/src/api/persistence/project/project.repository.mock.ts
@@ -4,6 +4,10 @@ import { ProjectEntity } from './project.entity.js';
 import { ProjectRepository } from './project.repository.js';
 
 export class InMemoryProjectRepository extends ProjectRepository {
+  async findOneById(_prisma: ProjectPrismaType, id: string): Promise<ProjectEntity> {
+    return buildProjectEntity({ id });
+  }
+
   async findOneBySubdomain(
     _prisma: BypassPrismaType,
     subdomain: string

--- a/src/api/routes/content.router.ts
+++ b/src/api/routes/content.router.ts
@@ -9,6 +9,7 @@ import { validateAccess } from '../middlewares/validateAccess.js';
 import { ContentRepository } from '../persistence/content/content.repository.js';
 import { ContentRevisionRepository } from '../persistence/contentRevision/contentRevision.repository.js';
 import { ContentTagRepository } from '../persistence/contentTag/contentTag.repository.js';
+import { PostRepository } from '../persistence/post/post.repository.js';
 import { ProjectRepository } from '../persistence/project/project.repository.js';
 import { ReviewRepository } from '../persistence/review/review.repository.js';
 import { TagRepository } from '../persistence/tag/tag.repository.js';
@@ -20,8 +21,6 @@ import { ContentService } from '../services/content.service.js';
 import { WebhookService } from '../services/webhook.service.js';
 import { ArchiveUseCase } from '../useCases/content/archive.useCase.js';
 import { archiveUseCaseSchema } from '../useCases/content/archive.useCase.schema.js';
-import { SimplifySentenceUseCase } from '../useCases/content/simplifySentence.useCase.js';
-import { simplifySentenceUseCaseSchema } from '../useCases/content/simplifySentence.useCase.schema.js';
 import { CreateContentTagsUseCase } from '../useCases/content/createContentTags.useCase.js';
 import { createContentTagsUseCaseSchema } from '../useCases/content/createContentTags.useCase.schema.js';
 import { GenerateSeoUseCase } from '../useCases/content/generateSeo.useCase.js';
@@ -38,6 +37,8 @@ import { RestoreContentUseCase } from '../useCases/content/restoreContent.useCas
 import { restoreContentUseCaseSchema } from '../useCases/content/restoreContent.useCase.schema.js';
 import { RevertContentUseCase } from '../useCases/content/revertContent.useCase.js';
 import { revertContentUseCaseSchema } from '../useCases/content/revertContent.useCase.schema.js';
+import { SimplifySentenceUseCase } from '../useCases/content/simplifySentence.useCase.js';
+import { simplifySentenceUseCaseSchema } from '../useCases/content/simplifySentence.useCase.schema.js';
 import { TrashContentUseCase } from '../useCases/content/trashContent.useCase.js';
 import { trashContentUseCaseSchema } from '../useCases/content/trashContent.useCase.schema.js';
 import { UpdateContentUseCase } from '../useCases/content/updateContent.useCase.js';
@@ -117,7 +118,8 @@ router.patch(
 
     const useCase = new UpdateContentUseCase(
       projectPrisma(validated.data.projectId),
-      new ContentRevisionRepository()
+      new ContentRevisionRepository(),
+      new PostRepository()
     );
     await useCase.execute(validated.data);
 

--- a/src/api/useCases/content/getPublishedContent.useCase.test.ts
+++ b/src/api/useCases/content/getPublishedContent.useCase.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { jest } from '@jest/globals';
 import { v4 } from 'uuid';
 import { projectPrisma } from '../../database/prisma/client.js';

--- a/src/api/useCases/content/updateContent.useCase.test.ts
+++ b/src/api/useCases/content/updateContent.useCase.test.ts
@@ -12,9 +12,14 @@ describe('UpdateContentUseCase', () => {
   const userId = v4();
   let updateContentUseCase: UpdateContentUseCase;
 
+  const prisma = projectPrisma(projectId);
+  jest.spyOn(prisma, '$transaction').mockImplementation(async (fn) => {
+    return await fn(prisma);
+  });
+
   beforeEach(() => {
     updateContentUseCase = new UpdateContentUseCase(
-      projectPrisma(projectId),
+      prisma,
       new InMemoryContentRevisionRepository(),
       new InMemoryPostRepository()
     );

--- a/src/api/useCases/content/updateContent.useCase.test.ts
+++ b/src/api/useCases/content/updateContent.useCase.test.ts
@@ -1,0 +1,45 @@
+/* eslint-disable max-len */
+import { expect, jest } from '@jest/globals';
+import { v4 } from 'uuid';
+import { projectPrisma } from '../../database/prisma/client.js';
+import { InMemoryContentRevisionRepository } from '../../persistence/contentRevision/contentRevision.repository.mock.js';
+import { buildPostEntity } from '../../persistence/post/post.entity.fixture.js';
+import { InMemoryPostRepository } from '../../persistence/post/post.repository.mock.js';
+import { UpdateContentUseCase } from './updateContent.useCase.js';
+
+describe('UpdateContentUseCase', () => {
+  const contentId = v4();
+  const projectId = v4();
+  const userId = v4();
+  let updateContentUseCase: UpdateContentUseCase;
+
+  beforeEach(() => {
+    updateContentUseCase = new UpdateContentUseCase(
+      projectPrisma(projectId),
+      new InMemoryContentRevisionRepository(),
+      new InMemoryPostRepository()
+    );
+    jest.clearAllMocks();
+  });
+
+  it('should unset isInit on post if post.isInit is true', async () => {
+    jest.spyOn(InMemoryPostRepository.prototype, 'findOneById').mockResolvedValue(
+      buildPostEntity({
+        isInit: true,
+      })
+    );
+    const updateSpy = jest.spyOn(InMemoryPostRepository.prototype, 'update').mockResolvedValue(
+      buildPostEntity({
+        isInit: false,
+      })
+    );
+
+    await updateContentUseCase.execute({
+      id: contentId,
+      projectId,
+      userId,
+    });
+
+    expect(updateSpy).toHaveBeenCalled();
+  });
+});

--- a/src/api/useCases/content/updateContent.useCase.test.ts
+++ b/src/api/useCases/content/updateContent.useCase.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { expect, jest } from '@jest/globals';
 import { v4 } from 'uuid';
 import { projectPrisma } from '../../database/prisma/client.js';

--- a/src/api/useCases/post/createPost.useCase.test.ts
+++ b/src/api/useCases/post/createPost.useCase.test.ts
@@ -1,0 +1,57 @@
+import { jest } from '@jest/globals';
+import { v4 } from 'uuid';
+import { projectPrisma } from '../../database/prisma/client.js';
+import { buildContentEntity } from '../../persistence/content/content.entity.fixture.js';
+import { InMemoryContentRepository } from '../../persistence/content/content.repository.mock.js';
+import { buildContentRevisionEntity } from '../../persistence/contentRevision/contentRevision.entity.fixture.js';
+import { InMemoryContentRevisionRepository } from '../../persistence/contentRevision/contentRevision.repository.mock.js';
+import { buildPostEntity } from '../../persistence/post/post.entity.fixture.js';
+import { InMemoryPostRepository } from '../../persistence/post/post.repository.mock.js';
+import { InMemoryProjectRepository } from '../../persistence/project/project.repository.mock.js';
+import { CreatePostUseCase } from './createPost.useCase.js';
+
+describe('CreatePostUseCase', () => {
+  const projectId = v4();
+  const userId = v4();
+  let createPostUseCase: CreatePostUseCase;
+
+  const prisma = projectPrisma(projectId);
+  jest.spyOn(prisma, '$transaction').mockImplementation(async (fn) => {
+    return await fn(prisma);
+  });
+
+  beforeEach(() => {
+    createPostUseCase = new CreatePostUseCase(
+      prisma,
+      new InMemoryProjectRepository(),
+      new InMemoryPostRepository(),
+      new InMemoryContentRepository(),
+      new InMemoryContentRevisionRepository()
+    );
+    jest.clearAllMocks();
+  });
+
+  it('should return init post if initPost exists', async () => {
+    const contentId = v4();
+
+    jest.spyOn(InMemoryPostRepository.prototype, 'findOneByIsInit').mockResolvedValue({
+      post: buildPostEntity({
+        isInit: true,
+      }),
+      content: buildContentEntity({
+        id: contentId,
+      }),
+      revision: buildContentRevisionEntity({}),
+    });
+
+    const result = await createPostUseCase.execute({
+      projectId,
+      userId,
+      sourceLanguage: 'ja',
+    });
+
+    expect(result).toMatchObject({
+      id: contentId,
+    });
+  });
+});

--- a/src/api/useCases/post/createPost.useCase.ts
+++ b/src/api/useCases/post/createPost.useCase.ts
@@ -21,6 +21,17 @@ export class CreatePostUseCase {
 
     const project = await this.projectRepository.findOneById(this.prisma, props.projectId);
 
+    // find isInit post
+    const initPost = await this.postRepository.findOneByIsInit(this.prisma);
+    if (initPost) {
+      return initPost.content.toRevisedContentResponse(
+        project,
+        [{ contentId: initPost.content.id, language: initPost.content.language }],
+        initPost.revision,
+        [initPost.revision]
+      );
+    }
+
     const { post, content, contentRevision } = PostEntity.Construct({
       projectId: projectId,
       language: sourceLanguage,

--- a/src/api/useCases/project/createProject.useCase.test.ts
+++ b/src/api/useCases/project/createProject.useCase.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { expect, jest } from '@jest/globals';
 import { v4 } from 'uuid';
 import { bypassPrisma } from '../../database/prisma/client.js';

--- a/src/api/useCases/review/closeReview.useCase.test.ts
+++ b/src/api/useCases/review/closeReview.useCase.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { expect, jest } from '@jest/globals';
 import { v4 } from 'uuid';
 import { projectPrisma } from '../../database/prisma/client.js';


### PR DESCRIPTION
## What?
Reuse empty post / content.

<!--
Write a brief description of your commitments.
-->

## Why?
A post is created every time you press new registration.

<!--
Write the need for the ticket.
-->

## How?
Add an init flag to posts and set it to false once the content is updated. Then, reuse any posts where init is true for new registrations.

<!--
For user functionality additions, write the operating procedures.
For development modifications, write the configuration procedure.
For bug fixes, write the reproduction procedure.
-->

## Notes

<!--
Write commitment details.
-->
