### PR TITLE
fix: don't reuse init post to avoid conflicts

### DIFF
--- a/src/api/persistence/content/content.repository.mock.ts
+++ b/src/api/persistence/content/content.repository.mock.ts
@@ -40,4 +40,14 @@ export class InMemoryContentRepository extends ContentRepository {
       }),
     ];
   }
+
+  async create(
+    _prisma: ProjectPrismaType,
+    contentEntity: ContentEntity
+  ): Promise<{ content: ContentEntity; createdBy: UserEntity }> {
+    return {
+      content: contentEntity,
+      createdBy: buildUserEntity(),
+    };
+  }
 }

--- a/src/api/persistence/contentRevision/contentRevision.repository.mock.ts
+++ b/src/api/persistence/contentRevision/contentRevision.repository.mock.ts
@@ -39,6 +39,13 @@ export class InMemoryContentRevisionRepository extends ContentRevisionRepository
     });
   }
 
+  async create(
+    _prisma: ProjectPrismaType,
+    entity: ContentRevisionEntity
+  ): Promise<ContentRevisionEntity> {
+    return entity;
+  }
+
   async update(
     _prisma: ProjectPrismaType,
     entity: ContentRevisionEntity

--- a/src/api/persistence/post/post.repository.mock.ts
+++ b/src/api/persistence/post/post.repository.mock.ts
@@ -1,8 +1,4 @@
 import { ProjectPrismaType } from '../../database/prisma/client.js';
-import { buildContentEntity } from '../content/content.entity.fixture.js';
-import { ContentEntity } from '../content/content.entity.js';
-import { buildContentRevisionEntity } from '../contentRevision/contentRevision.entity.fixture.js';
-import { ContentRevisionEntity } from '../contentRevision/contentRevision.entity.js';
 import { buildPostEntity } from './post.entity.fixture.js';
 import { PostEntity } from './post.entity.js';
 import { PostRepository } from './post.repository.js';
@@ -12,6 +8,10 @@ export class InMemoryPostRepository extends PostRepository {
     return buildPostEntity({
       id,
     });
+  }
+
+  async create(_prisma: ProjectPrismaType, postEntity: PostEntity): Promise<PostEntity> {
+    return postEntity;
   }
 
   async update(_prisma: ProjectPrismaType, post: PostEntity): Promise<PostEntity> {

--- a/src/api/persistence/post/post.repository.mock.ts
+++ b/src/api/persistence/post/post.repository.mock.ts
@@ -14,20 +14,6 @@ export class InMemoryPostRepository extends PostRepository {
     });
   }
 
-  async findOneByIsInit(_prisma: ProjectPrismaType): Promise<{
-    post: PostEntity;
-    content: ContentEntity;
-    revision: ContentRevisionEntity;
-  } | null> {
-    return {
-      post: buildPostEntity({
-        isInit: false,
-      }),
-      content: buildContentEntity({}),
-      revision: buildContentRevisionEntity({}),
-    };
-  }
-
   async update(_prisma: ProjectPrismaType, post: PostEntity): Promise<PostEntity> {
     return post;
   }

--- a/src/api/persistence/post/post.repository.ts
+++ b/src/api/persistence/post/post.repository.ts
@@ -66,32 +66,6 @@ export class PostRepository {
     };
   }
 
-  async findOneByIsInit(prisma: ProjectPrismaType): Promise<{
-    post: PostEntity;
-    content: ContentEntity;
-    revision: ContentRevisionEntity;
-  } | null> {
-    const record = await prisma.post.findFirst({
-      where: {
-        isInit: true,
-      },
-      include: {
-        contents: true,
-        contentRevisions: true,
-      },
-    });
-
-    return record
-      ? {
-          post: PostEntity.Reconstruct<Post, PostEntity>(record),
-          content: ContentEntity.Reconstruct<Content, ContentEntity>(record.contents[0]),
-          revision: ContentRevisionEntity.Reconstruct<ContentRevision, ContentRevisionEntity>(
-            record.contentRevisions[0]
-          ),
-        }
-      : null;
-  }
-
   async findMany(
     prisma: ProjectPrismaType,
     options?: {

--- a/src/api/useCases/post/createPost.useCase.test.ts
+++ b/src/api/useCases/post/createPost.useCase.test.ts
@@ -6,7 +6,9 @@ import { InMemoryContentRevisionRepository } from '../../persistence/contentRevi
 import { InMemoryPostRepository } from '../../persistence/post/post.repository.mock.js';
 import { InMemoryProjectRepository } from '../../persistence/project/project.repository.mock.js';
 import { CreatePostUseCase } from './createPost.useCase.js';
-import { beforeEach } from 'node:test';
+import { buildPostEntity } from '../../persistence/post/post.entity.fixture.js';
+import { buildContentEntity } from '../../persistence/content/content.entity.fixture.js';
+import { buildUserEntity } from '../../persistence/user/user.entity.fixture.js';
 
 describe('CreatePostUseCase', () => {
   const projectId = v4();
@@ -27,5 +29,30 @@ describe('CreatePostUseCase', () => {
       new InMemoryContentRevisionRepository()
     );
     jest.clearAllMocks();
+  });
+
+  it('should return content with draft status', async () => {
+    const postId = v4();
+
+    jest.spyOn(InMemoryContentRepository.prototype, 'create').mockResolvedValue({
+      content: buildContentEntity({
+        postId,
+      }),
+      createdBy: buildUserEntity(),
+    });
+
+    const result = await createPostUseCase.execute({
+      projectId,
+      userId,
+      sourceLanguage: 'ja',
+    });
+
+    expect(result).toMatchObject({
+      postId,
+      language: 'ja',
+      status: {
+        currentStatus: 'draft',
+      },
+    });
   });
 });

--- a/src/api/useCases/post/createPost.useCase.test.ts
+++ b/src/api/useCases/post/createPost.useCase.test.ts
@@ -1,14 +1,12 @@
 import { jest } from '@jest/globals';
 import { v4 } from 'uuid';
 import { projectPrisma } from '../../database/prisma/client.js';
-import { buildContentEntity } from '../../persistence/content/content.entity.fixture.js';
 import { InMemoryContentRepository } from '../../persistence/content/content.repository.mock.js';
-import { buildContentRevisionEntity } from '../../persistence/contentRevision/contentRevision.entity.fixture.js';
 import { InMemoryContentRevisionRepository } from '../../persistence/contentRevision/contentRevision.repository.mock.js';
-import { buildPostEntity } from '../../persistence/post/post.entity.fixture.js';
 import { InMemoryPostRepository } from '../../persistence/post/post.repository.mock.js';
 import { InMemoryProjectRepository } from '../../persistence/project/project.repository.mock.js';
 import { CreatePostUseCase } from './createPost.useCase.js';
+import { beforeEach } from 'node:test';
 
 describe('CreatePostUseCase', () => {
   const projectId = v4();
@@ -29,29 +27,5 @@ describe('CreatePostUseCase', () => {
       new InMemoryContentRevisionRepository()
     );
     jest.clearAllMocks();
-  });
-
-  it('should return init post if initPost exists', async () => {
-    const contentId = v4();
-
-    jest.spyOn(InMemoryPostRepository.prototype, 'findOneByIsInit').mockResolvedValue({
-      post: buildPostEntity({
-        isInit: true,
-      }),
-      content: buildContentEntity({
-        id: contentId,
-      }),
-      revision: buildContentRevisionEntity({}),
-    });
-
-    const result = await createPostUseCase.execute({
-      projectId,
-      userId,
-      sourceLanguage: 'ja',
-    });
-
-    expect(result).toMatchObject({
-      id: contentId,
-    });
   });
 });

--- a/src/api/useCases/post/createPost.useCase.ts
+++ b/src/api/useCases/post/createPost.useCase.ts
@@ -21,17 +21,6 @@ export class CreatePostUseCase {
 
     const project = await this.projectRepository.findOneById(this.prisma, props.projectId);
 
-    // find isInit post
-    const initPost = await this.postRepository.findOneByIsInit(this.prisma);
-    if (initPost) {
-      return initPost.content.toRevisedContentResponse(
-        project,
-        [{ contentId: initPost.content.id, language: initPost.content.language }],
-        initPost.revision,
-        [initPost.revision]
-      );
-    }
-
     const { post, content, contentRevision } = PostEntity.Construct({
       projectId: projectId,
       language: sourceLanguage,


### PR DESCRIPTION
## What?
Don't reuse init post to avoid conflicts.

<!--
Write a brief description of your commitments.
-->

## Why?
Avoid conflicts.

<!--
Write the need for the ticket.
-->

## Notes
Add a batch that will remove the init post.